### PR TITLE
Added oracle delta plugins.

### DIFF
--- a/oracle-delta-plugins/pom.xml
+++ b/oracle-delta-plugins/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2020 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>database-delta-plugins</artifactId>
+    <groupId>io.cdap.delta</groupId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>oracle-delta-plugins</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.debezium</groupId>
+      <artifactId>debezium-connector-oracle</artifactId>
+      <version>${debezium.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.delta</groupId>
+      <artifactId>delta-plugins-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/oracle-delta-plugins/pom.xml
+++ b/oracle-delta-plugins/pom.xml
@@ -33,10 +33,51 @@
       <artifactId>debezium-connector-oracle</artifactId>
       <version>${debezium.version}</version>
     </dependency>
+    <!-- TODO: load xstream dependency and bind with the plugin given by user -->
+    <dependency>
+      <groupId>com.oracle.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>12.0.1.0</version>
+    </dependency>
     <dependency>
       <groupId>io.cdap.delta</groupId>
       <artifactId>delta-plugins-common</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.5.1</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+            <!--Only @Plugin classes in the export packages will be included as plugin-->
+            <_exportcontents>
+              io.cdap.delta.oracle.*
+            </_exportcontents>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>io.cdap</groupId>
+        <artifactId>cdap-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/oracle-delta-plugins/pom.xml
+++ b/oracle-delta-plugins/pom.xml
@@ -38,6 +38,7 @@
       <groupId>com.oracle.xstream</groupId>
       <artifactId>xstream</artifactId>
       <version>12.0.1.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.cdap.delta</groupId>
@@ -72,11 +73,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>io.cdap</groupId>
-        <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConfig.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConfig.java
@@ -49,7 +49,8 @@ public class OracleConfig extends PluginConfig {
   @Description("Name of the JDBC plugin to use.")
   private String jdbcPluginName;
 
-  @Description("Path to load JDBC native libraries.")
+  // TODO: implement the proper way load JDBC from remote path
+  @Description("Path to load JDBC native libraries from local.")
   private String libPath;
 
   @Nullable
@@ -58,7 +59,7 @@ public class OracleConfig extends PluginConfig {
   private String connectionString;
 
   @Nullable
-  @Description("List of tables to consumer changes for.")
+  @Description("A comma separated list of tables to consumer changes for.")
   private String tableWhiteList;
 
   public OracleConfig(String host, int port, String user, String password,

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConfig.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConfig.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.oracle;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.plugin.PluginConfig;
+
+import javax.annotation.Nullable;
+
+/**
+ * Plugin configuration for the Oracle.
+ */
+public class OracleConfig extends PluginConfig {
+  @Description("Hostname of the Oracle server to read from.")
+  private String host;
+
+  @Description("Port to use to connect to the Oracle server.")
+  private int port;
+
+  @Description("Username to use to connect to the Oracle server.")
+  private String user;
+
+  @Description("Password to use to connect to the Oracle server.")
+  private String password;
+
+  @Description("DB name of the Oracle server.")
+  private String dbName;
+
+  @Description("PDB name of the Oracle server.")
+  private String pdbName;
+
+  @Description("XStream out server name of the Oracle server.")
+  private String outServerName;
+
+  @Description("Name of the JDBC plugin to use.")
+  private String jdbcPluginName;
+
+  @Description("Path to load JDBC native libraries.")
+  private String libPath;
+
+  @Nullable
+  @Description("Connection string to use when connecting to the database through JDBC. "
+    + "This is required if a JDBC plugin was specified.")
+  private String connectionString;
+
+  @Nullable
+  @Description("List of tables to consumer changes for.")
+  private String tableWhiteList;
+
+  public OracleConfig(String host, int port, String user, String password,
+                      String dbName, String pdbName, String outServerName,
+                      String jdbcPluginName, String libPath,
+                      @Nullable String connectionString,
+                      @Nullable String tableWhiteList) {
+    this.host = host;
+    this.port = port;
+    this.user = user;
+    this.password = password;
+    this.dbName = dbName;
+    this.pdbName = pdbName;
+    this.outServerName = outServerName;
+    this.jdbcPluginName = jdbcPluginName;
+    this.libPath = libPath;
+    this.connectionString = connectionString;
+    this.tableWhiteList = tableWhiteList;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public String getDbName() {
+    return dbName;
+  }
+
+  public String getPdbName() {
+    return pdbName;
+  }
+
+  public String getOutServerName() {
+    return outServerName;
+  }
+
+  public String getJdbcPluginName() {
+    return jdbcPluginName;
+  }
+
+  public String getLibPath() {
+    return libPath;
+  }
+
+  public String getConnectionString() {
+    return connectionString == null ? "jdbc:oracle:oci:@" + host + ":" + port + "/" + dbName : connectionString;
+  }
+
+  public String getTableWhiteList() {
+    return tableWhiteList == null ? "" : tableWhiteList;
+  }
+}

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConfig.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConfig.java
@@ -58,15 +58,10 @@ public class OracleConfig extends PluginConfig {
     + "This is required if a JDBC plugin was specified.")
   private String connectionString;
 
-  @Nullable
-  @Description("A comma separated list of tables to consumer changes for.")
-  private String tableWhiteList;
-
   public OracleConfig(String host, int port, String user, String password,
                       String dbName, String pdbName, String outServerName,
                       String jdbcPluginName, String libPath,
-                      @Nullable String connectionString,
-                      @Nullable String tableWhiteList) {
+                      @Nullable String connectionString) {
     this.host = host;
     this.port = port;
     this.user = user;
@@ -77,7 +72,6 @@ public class OracleConfig extends PluginConfig {
     this.jdbcPluginName = jdbcPluginName;
     this.libPath = libPath;
     this.connectionString = connectionString;
-    this.tableWhiteList = tableWhiteList;
   }
 
   public String getHost() {
@@ -118,9 +112,5 @@ public class OracleConfig extends PluginConfig {
 
   public String getConnectionString() {
     return connectionString == null ? "jdbc:oracle:oci:@" + host + ":" + port + "/" + dbName : connectionString;
-  }
-
-  public String getTableWhiteList() {
-    return tableWhiteList == null ? "" : tableWhiteList;
   }
 }

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConstantOffsetBackingStore.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConstantOffsetBackingStore.java
@@ -18,7 +18,11 @@ package io.cdap.delta.oracle;
 
 import com.google.gson.Gson;
 import io.cdap.cdap.api.common.Bytes;
+import io.debezium.connector.oracle.SourceInfo;
+import io.debezium.util.Strings;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.storage.MemoryOffsetBackingStore;
 
 import java.nio.ByteBuffer;
@@ -29,32 +33,88 @@ import java.util.Map;
  * Returns an offset based on a configuration setting and doesn't actually store anything.
  * This is because the Delta app needs to have control over when offsets are stored and not Debezium.
  *
- *
  * OffsetBackingStore is pretty weird... keys are ByteBuffer representations of Strings like:
  *
  * {"schema":null,"payload":["delta",{"server":"dummy"}]}
  *
  * and values are ByteBuffer representations of Strings like:
  *
- * {"scn":16838027}
+ * {"scn":16838027,"lcr_position":"090909090909sfsdfsfsd09","snapshot":true,"snapshot_completed":false}
  */
 public class OracleConstantOffsetBackingStore extends MemoryOffsetBackingStore {
+  static final String SNAPSHOT_COMPLETED = "snapshot_completed";
   private static final Gson GSON = new Gson();
+  private static final String SOURCE = "source";
   private static final String KEY = "{\"schema\":null,\"payload\":[\"delta\",{\"server\":\"dummy\"}]}";
 
   @Override
   public void configure(WorkerConfig config) {
-    // TODO: remove hack once EmbeddedEngine is no longer used
+    Map<String, String> originalConfig = config.originalsStrings();
+    String scnStr = originalConfig.get(SourceInfo.SCN_KEY);
+    String lcrPositionStr = originalConfig.get(SourceInfo.LCR_POSITION_KEY);
+    String snapshotStr = originalConfig.get(SourceInfo.SNAPSHOT_KEY);
+    String snapshotCompletedStr = originalConfig.get(SNAPSHOT_COMPLETED);
 
-    String offsetStr = config.getString("offset.storage.file.filename");
-    if (offsetStr.isEmpty()) {
+    Map<String, Object> offset = new HashMap<>();
+    if (!Strings.isNullOrEmpty(scnStr)) {
+      offset.put(SourceInfo.SCN_KEY, Long.valueOf(scnStr));
+    }
+    if (!Strings.isNullOrEmpty(lcrPositionStr)) {
+      offset.put(SourceInfo.LCR_POSITION_KEY, lcrPositionStr);
+    }
+    if (!Strings.isNullOrEmpty(snapshotStr)) {
+      offset.put(SourceInfo.SNAPSHOT_KEY, Boolean.valueOf(snapshotStr));
+    }
+    if (!Strings.isNullOrEmpty(snapshotCompletedStr)) {
+      offset.put(SNAPSHOT_COMPLETED, Boolean.valueOf(snapshotCompletedStr));
+    }
+
+    if (offset.isEmpty()) {
       return;
     }
 
-    Map<String, Object> offset = new HashMap<>();
-    offset.put("scn", Long.parseLong(offsetStr));
     byte[] offsetBytes = Bytes.toBytes(GSON.toJson(offset));
-
     data.put(ByteBuffer.wrap(Bytes.toBytes(KEY)), ByteBuffer.wrap(offsetBytes));
+  }
+
+  static Map<String, String> deserializeOffsets(Map<String, byte[]> offsets) {
+    Map<String, String> offsetConfigMap = new HashMap<>();
+    String scn = Bytes.toString(offsets.get(SourceInfo.SCN_KEY));
+    String lcrPosition = Bytes.toString(offsets.get(SourceInfo.LCR_POSITION_KEY));
+    String snapshot = Bytes.toString(offsets.get(SourceInfo.SNAPSHOT_KEY));
+    String snapshotCompleted = Bytes.toString(offsets.get(SNAPSHOT_COMPLETED));
+
+    offsetConfigMap.put(SourceInfo.SCN_KEY, scn == null ? "" : scn);
+    offsetConfigMap.put(SourceInfo.LCR_POSITION_KEY, lcrPosition == null ? "" : lcrPosition);
+    offsetConfigMap.put(SourceInfo.SNAPSHOT_KEY, snapshot == null ? "" : snapshot);
+    offsetConfigMap.put(SNAPSHOT_COMPLETED, snapshotCompleted == null ? "" : snapshotCompleted);
+
+    return offsetConfigMap;
+  }
+
+  static Map<String, byte[]> serializeOffsets(SourceRecord sourceRecord) {
+    Map<String, ?> sourceOffset = sourceRecord.sourceOffset();
+    Struct source = (Struct) ((Struct) sourceRecord.value()).get(SOURCE);
+    Boolean snapshotCompleted = (Boolean) sourceOffset.get(SNAPSHOT_COMPLETED);
+    Long scn = (Long) source.get(SourceInfo.SCN_KEY);
+    String lcrPosition = (String) source.get(SourceInfo.LCR_POSITION_KEY);
+    Boolean snapshot = (Boolean) source.get(SourceInfo.SNAPSHOT_KEY);;
+
+    Map<String, byte[]> deltaOffset = new HashMap<>();
+
+    if (scn != null) {
+      deltaOffset.put(SourceInfo.SCN_KEY, Bytes.toBytes(scn.toString()));
+    }
+    if (lcrPosition != null) {
+      deltaOffset.put(SourceInfo.LCR_POSITION_KEY, Bytes.toBytes(lcrPosition));
+    }
+    if (snapshot != null) {
+      deltaOffset.put(SourceInfo.SNAPSHOT_KEY, Bytes.toBytes(snapshot.toString()));
+    }
+    if (snapshotCompleted != null) {
+      deltaOffset.put(SNAPSHOT_COMPLETED, Bytes.toBytes(snapshotCompleted.toString()));
+    }
+
+    return deltaOffset;
   }
 }

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConstantOffsetBackingStore.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConstantOffsetBackingStore.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.oracle;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.common.Bytes;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.storage.MemoryOffsetBackingStore;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Returns an offset based on a configuration setting and doesn't actually store anything.
+ * This is because the Delta app needs to have control over when offsets are stored and not Debezium.
+ *
+ *
+ * OffsetBackingStore is pretty weird... keys are ByteBuffer representations of Strings like:
+ *
+ * {"schema":null,"payload":["delta",{"server":"dummy"}]}
+ *
+ * and values are ByteBuffer representations of Strings like:
+ *
+ * {"scn":16838027}
+ */
+public class OracleConstantOffsetBackingStore extends MemoryOffsetBackingStore {
+  private static final Gson GSON = new Gson();
+  private static final String KEY = "{\"schema\":null,\"payload\":[\"delta\",{\"server\":\"dummy\"}]}";
+
+  @Override
+  public void configure(WorkerConfig config) {
+    // TODO: remove hack once EmbeddedEngine is no longer used
+
+    String offsetStr = config.getString("offset.storage.file.filename");
+    if (offsetStr.isEmpty()) {
+      return;
+    }
+
+    Map<String, Object> offset = new HashMap<>();
+    offset.put("scn", Long.parseLong(offsetStr));
+    byte[] offsetBytes = Bytes.toBytes(GSON.toJson(offset));
+
+    data.put(ByteBuffer.wrap(Bytes.toBytes(KEY)), ByteBuffer.wrap(offsetBytes));
+  }
+}

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConstantOffsetBackingStore.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConstantOffsetBackingStore.java
@@ -41,6 +41,7 @@ import java.util.Map;
  */
 public class OracleConstantOffsetBackingStore extends MemoryOffsetBackingStore {
   static final String SNAPSHOT_COMPLETED = "snapshot_completed";
+  private static final Gson gson = new Gson();
   // The key is hardcoded here
   private static final ByteBuffer KEY =
     StandardCharsets.UTF_8.encode("{\"schema\":null,\"payload\":[\"delta\",{\"server\":\"dummy\"}]}");
@@ -70,7 +71,7 @@ public class OracleConstantOffsetBackingStore extends MemoryOffsetBackingStore {
     if (offset.isEmpty()) {
       return;
     }
-    Gson gson = new Gson();
+
     data.put(KEY, StandardCharsets.UTF_8.encode(gson.toJson(offset)));
   }
 }

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleDeltaSource.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleDeltaSource.java
@@ -32,7 +32,6 @@ import io.cdap.delta.api.assessment.TableRegistry;
 import io.cdap.delta.common.DriverCleanup;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.List;
@@ -72,15 +71,6 @@ public class OracleDeltaSource implements DeltaSource {
       driverCleanup.close();
     } catch (IOException e) {
       throw new RuntimeException("Unable to de-register jdbc driver plugin: " + e.getMessage(), e);
-    }
-
-    try {
-      System.setProperty("java.library.path", conf.getLibPath());
-      Field fieldSysPath = ClassLoader.class.getDeclaredField("sys_paths");
-      fieldSysPath.setAccessible(true);
-      fieldSysPath.set(null, null);
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to load jdbc native libraries.");
     }
   }
 

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleDeltaSource.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleDeltaSource.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.oracle;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.delta.api.Configurer;
+import io.cdap.delta.api.DeltaSource;
+import io.cdap.delta.api.DeltaSourceContext;
+import io.cdap.delta.api.EventEmitter;
+import io.cdap.delta.api.EventReader;
+import io.cdap.delta.api.SourceTable;
+import io.cdap.delta.api.assessment.TableAssessor;
+import io.cdap.delta.api.assessment.TableDetail;
+import io.cdap.delta.api.assessment.TableRegistry;
+import io.cdap.delta.common.DriverCleanup;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * For oracle source plugin.
+ */
+@Plugin(type = DeltaSource.PLUGIN_TYPE)
+@Name(OracleDeltaSource.NAME)
+@Description("Delta source for Oracle.")
+public class OracleDeltaSource implements DeltaSource {
+  public static final String NAME = "oracle";
+  private final OracleConfig conf;
+
+  public OracleDeltaSource(OracleConfig conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public void configure(Configurer configurer) {
+    DriverCleanup driverCleanup;
+    Class<? extends Driver> driverClass = configurer.usePluginClass("jdbc",
+                                                                    conf.getJdbcPluginName(),
+                                                                    "jdbc",
+                                                                    PluginProperties.builder().build());
+    if (driverClass == null) {
+      throw new RuntimeException("Unable to find jdbc driver plugin : " + conf.getJdbcPluginName());
+    }
+
+    try {
+      driverCleanup = DriverCleanup.ensureJDBCDriverIsAvailable(driverClass, conf.getConnectionString());
+    } catch (IllegalAccessException | InstantiationException | SQLException e) {
+      throw new RuntimeException("Unable to instantiate jdbc driver plugin: " + e.getMessage(), e);
+    }
+
+    try {
+      driverCleanup.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to de-register jdbc driver plugin: " + e.getMessage(), e);
+    }
+
+    try {
+      System.setProperty("java.library.path", conf.getLibPath());
+      Field fieldSysPath = ClassLoader.class.getDeclaredField("sys_paths");
+      fieldSysPath.setAccessible(true);
+      fieldSysPath.set(null, null);
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to load jdbc native libraries.");
+    }
+  }
+
+  @Override
+  public EventReader createReader(List<SourceTable> tables, DeltaSourceContext context, EventEmitter eventEmitter) {
+    // TODO: incorporate with list of tables into event reader.
+    return new OracleEventReader(conf, context, eventEmitter);
+  }
+
+  @Override
+  public TableRegistry createTableRegistry(Configurer configurer) {
+    // TODO: implement table registry
+    return null;
+  }
+
+  @Override
+  public TableAssessor<TableDetail> createTableAssessor(Configurer configurer) throws Exception {
+    // TODO: implement accesssment
+    return null;
+  }
+}

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleDeltaSource.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleDeltaSource.java
@@ -52,7 +52,6 @@ public class OracleDeltaSource implements DeltaSource {
 
   @Override
   public void configure(Configurer configurer) {
-    DriverCleanup driverCleanup;
     Class<? extends Driver> driverClass = configurer.usePluginClass("jdbc",
                                                                     conf.getJdbcPluginName(),
                                                                     "jdbc",
@@ -61,14 +60,10 @@ public class OracleDeltaSource implements DeltaSource {
       throw new RuntimeException("Unable to find jdbc driver plugin : " + conf.getJdbcPluginName());
     }
 
-    try {
-      driverCleanup = DriverCleanup.ensureJDBCDriverIsAvailable(driverClass, conf.getConnectionString());
+    try (DriverCleanup driverCleanup =
+           DriverCleanup.ensureJDBCDriverIsAvailable(driverClass, conf.getConnectionString())) {
     } catch (IllegalAccessException | InstantiationException | SQLException e) {
       throw new RuntimeException("Unable to instantiate jdbc driver plugin: " + e.getMessage(), e);
-    }
-
-    try {
-      driverCleanup.close();
     } catch (IOException e) {
       throw new RuntimeException("Unable to de-register jdbc driver plugin: " + e.getMessage(), e);
     }
@@ -83,12 +78,12 @@ public class OracleDeltaSource implements DeltaSource {
   @Override
   public TableRegistry createTableRegistry(Configurer configurer) {
     // TODO: implement table registry
-    return null;
+    throw new UnsupportedOperationException("createTableRegistry is not implemented yet");
   }
 
   @Override
   public TableAssessor<TableDetail> createTableAssessor(Configurer configurer) throws Exception {
     // TODO: implement accesssment
-    return null;
+    throw new UnsupportedOperationException("createTableAssessor is not implemented yet");
   }
 }

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
@@ -73,7 +73,7 @@ public class OracleEventReader implements EventReader {
       .with("offset.flush.interval.ms", 1000);
 
     // bind offset configs with debezium config
-    deserializeOffsets(offset.get()).forEach(builder::with);
+    convertOffsets(offset.get()).forEach(builder::with);
 
     Configuration debeziumConf = builder
       /* begin connector properties */
@@ -89,7 +89,6 @@ public class OracleEventReader implements EventReader {
       // below is a workaround fix for ORA-21560 issue, Jira to track: https://issues.cask.co/browse/PLUGIN-105
       .with("database.oracle.version", 11)
       .with("database.server.name", "dummy") // this is the kafka topic for hosted debezium - it doesn't matter
-      .with("table.whitelist", config.getTableWhiteList())
       .build();
 
     DBSchemaHistory.deltaRuntimeContext = context;
@@ -122,7 +121,8 @@ public class OracleEventReader implements EventReader {
     executorService.shutdown();
   }
 
-  private Map<String, String> deserializeOffsets(Map<String, byte[]> offsets) {
+  // This method is used for converting a CDAP offset into a debezium offset
+  private Map<String, String> convertOffsets(Map<String, byte[]> offsets) {
     Map<String, String> offsetConfigMap = new HashMap<>();
     String scn = Bytes.toString(offsets.get(SourceInfo.SCN_KEY));
     String lcrPosition = Bytes.toString(offsets.get(SourceInfo.LCR_POSITION_KEY));

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
@@ -74,7 +74,7 @@ public class OracleEventReader implements EventReader {
 
     Configuration debeziumConf = Configuration.create()
       .with("connector.class", OracleConnector.class.getName())
-      .with("offset.storage", ConstantOffsetBackingStore.class.getName())
+      .with("offset.storage", OracleConstantOffsetBackingStore.class.getName())
       .with("offset.storage.file.filename", scn)
       .with("offset.flush.interval.ms", 1000)
       /* begin connector properties */

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
@@ -16,35 +16,21 @@
 
 package io.cdap.delta.oracle;
 
-import io.cdap.cdap.api.common.Bytes;
-import io.cdap.cdap.api.data.format.StructuredRecord;
-import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.delta.api.DDLEvent;
-import io.cdap.delta.api.DDLOperation;
-import io.cdap.delta.api.DMLEvent;
-import io.cdap.delta.api.DMLOperation;
 import io.cdap.delta.api.DeltaSourceContext;
 import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.EventReader;
 import io.cdap.delta.api.Offset;
-import io.cdap.delta.common.ConstantOffsetBackingStore;
 import io.cdap.delta.common.DBSchemaHistory;
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnector;
 import io.debezium.embedded.EmbeddedEngine;
-import org.apache.kafka.connect.data.Struct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.lang.reflect.Field;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Event reader for oracle.
@@ -56,27 +42,36 @@ public class OracleEventReader implements EventReader {
   private final ExecutorService executorService;
   private final EventEmitter emitter;
   private EmbeddedEngine engine;
-  private Set<String> snapshotTableStore;
 
   public OracleEventReader(OracleConfig config, DeltaSourceContext context, EventEmitter emitter) {
     this.config = config;
     this.context = context;
     this.emitter = emitter;
     this.executorService = Executors.newSingleThreadExecutor();
-    this.snapshotTableStore = new HashSet<>();
   }
 
   @Override
   public void start(Offset offset) {
-    byte[] scnBytes = offset.get().get("scn");
-    String scn = scnBytes == null ? "" : Long.toString(Bytes.toLong(scnBytes));
-    LOG.info("scn : " + scn);
 
-    Configuration debeziumConf = Configuration.create()
+    // load native jdbc libraries into jvm during runtime
+    try {
+      System.setProperty("java.library.path", config.getLibPath());
+      Field fieldSysPath = ClassLoader.class.getDeclaredField("sys_paths");
+      fieldSysPath.setAccessible(true);
+      fieldSysPath.set(null, null);
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to load jdbc native libraries.");
+    }
+
+    Configuration.Builder builder = Configuration.create()
       .with("connector.class", OracleConnector.class.getName())
       .with("offset.storage", OracleConstantOffsetBackingStore.class.getName())
-      .with("offset.storage.file.filename", scn)
-      .with("offset.flush.interval.ms", 1000)
+      .with("offset.flush.interval.ms", 1000);
+
+    // bind offset configs with debezium config
+    OracleConstantOffsetBackingStore.deserializeOffsets(offset.get()).forEach(builder::with);
+
+    Configuration debeziumConf = builder
       /* begin connector properties */
       .with("name", "delta")
       .with("database.hostname", config.getHost())
@@ -87,7 +82,7 @@ public class OracleEventReader implements EventReader {
       .with("database.pdb.name", config.getPdbName())
       .with("database.out.server.name", config.getOutServerName())
       .with("database.history", DBSchemaHistory.class.getName())
-      // workaround fix for issue: https://groups.google.com/forum/#!topic/debezium/FrN5PFRFlmQ
+      // below is a workaround fix for ORA-21560 issue, Jira to track: https://issues.cask.co/browse/PLUGIN-105
       .with("database.oracle.version", 11)
       .with("database.server.name", "dummy") // this is the kafka topic for hosted debezium - it doesn't matter
       .with("table.whitelist", config.getTableWhiteList())
@@ -101,93 +96,7 @@ public class OracleEventReader implements EventReader {
       // Create the engine with this configuration ...
       engine = EmbeddedEngine.create()
         .using(debeziumConf)
-        .notifying(sourceRecord -> {
-          if (sourceRecord.value() == null) {
-            return;
-          }
-
-          Map<String, ?> sourceOffset = sourceRecord.sourceOffset();
-          Boolean snapshotCompleted = (Boolean) sourceOffset.get("snapshot_completed");
-          Map<String, byte[]> deltaOffset = new HashMap<>();
-
-          StructuredRecord val = Records.convert((Struct) sourceRecord.value());
-          StructuredRecord source = val.get("source");
-          String databaseName = config.getDbName();
-          String recordName = val.getSchema().getRecordName();
-          String[] parts = recordName.split("\\.");
-          String tableName = parts[1] + "_" + parts[2]; // schema_table as name
-          String transactionId = source.get("txId");
-          StructuredRecord before = val.get("before");
-          StructuredRecord after = val.get("after");
-          Long ingestTime = val.get("ts_ms");
-          Long logPosition;
-
-          if (snapshotCompleted == null) {
-            logPosition = source.get("scn");
-          } else {
-            logPosition = (Long) sourceOffset.get("scn");
-          }
-
-          deltaOffset.put("scn", Bytes.toBytes(logPosition));
-          Offset recordOffset = new Offset(deltaOffset);
-
-          DMLOperation op;
-          String opStr = val.get("op");
-
-          if ("c".equals(opStr)) {
-            op = DMLOperation.INSERT;
-            context.getMetrics().count("ddl.source.INSERT.count", 1);
-          } else if ("u".equals(opStr)) {
-            op = DMLOperation.UPDATE;
-            context.getMetrics().count("ddl.source.UPDATE.count", 1);
-          } else if ("d".equals(opStr)) {
-            op = DMLOperation.DELETE;
-            context.getMetrics().count("ddl.source.DELETE.count", 1);
-          } else if ("r".equals(opStr)) {
-            // create a normal INSERT DML event, only during snapshotting process that opStr is equal to 'r'
-            op = DMLOperation.INSERT;
-            context.getMetrics().count("ddl.source.Snapshot.INSERT.count", 1);
-          } else {
-            LOG.warn("Skipping unknown operation type '{}'", opStr);
-            context.getMetrics().count("ddl.source.OTHER.count", 1);
-            return;
-          }
-
-          if (!snapshotTableStore.contains(tableName)) {
-            LOG.info("Snapshotting for table " + tableName + " started.");
-            StructuredRecord key = Records.convert((Struct) sourceRecord.key());
-            List<Schema.Field> fields = key.getSchema().getFields();
-            List<String> primaryKeyFields = fields.stream().map(Schema.Field::getName).collect(Collectors.toList());
-            // this is a hack to get schema from either 'before' or 'after' field
-            Schema schema = op == DMLOperation.DELETE ? before.getSchema() : after.getSchema();
-
-            emitter.emit(DDLEvent.builder()
-                           .setDatabase(databaseName)
-                           .setOffset(recordOffset)
-                           .setOperation(DDLOperation.CREATE_TABLE)
-                           .setTable(tableName)
-                           .setSchema(schema)
-                           .setPrimaryKey(primaryKeyFields)
-                           .build());
-            snapshotTableStore.add(tableName);
-          }
-
-          if (op == DMLOperation.DELETE) {
-            emitter.emit(new DMLEvent(recordOffset, op, databaseName, tableName, before, transactionId, ingestTime));
-          } else {
-            emitter.emit(new DMLEvent(recordOffset, op, databaseName, tableName, after, transactionId, ingestTime));
-
-            if (snapshotCompleted != null) {
-              if (snapshotCompleted) {
-                LOG.info("Snapshotting for table " + tableName + " completed.");
-              } else {
-                LOG.debug("Snapshotting for table " + tableName + " was still undergoing.");
-              }
-            } else {
-              LOG.debug("New DML event " + opStr + " for table " + tableName);
-            }
-          }
-        })
+        .notifying(new OracleSourceRecordConsumer(config.getDbName(), emitter))
         .using((success, message, error) -> {
           if (!success) {
             LOG.error("Failed - {}", message, error);

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.oracle;
+
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.delta.api.DDLEvent;
+import io.cdap.delta.api.DDLOperation;
+import io.cdap.delta.api.DMLEvent;
+import io.cdap.delta.api.DMLOperation;
+import io.cdap.delta.api.DeltaSourceContext;
+import io.cdap.delta.api.EventEmitter;
+import io.cdap.delta.api.EventReader;
+import io.cdap.delta.api.Offset;
+import io.cdap.delta.common.ConstantOffsetBackingStore;
+import io.cdap.delta.common.DBSchemaHistory;
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnector;
+import io.debezium.embedded.EmbeddedEngine;
+import org.apache.kafka.connect.data.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Event reader for oracle.
+ */
+public class OracleEventReader implements EventReader {
+  private static final Logger LOG = LoggerFactory.getLogger(OracleEventReader.class);
+  private final OracleConfig config;
+  private final DeltaSourceContext context;
+  private final ExecutorService executorService;
+  private final EventEmitter emitter;
+  private EmbeddedEngine engine;
+  private Set<String> snapshotTableStore;
+
+  public OracleEventReader(OracleConfig config, DeltaSourceContext context, EventEmitter emitter) {
+    this.config = config;
+    this.context = context;
+    this.emitter = emitter;
+    this.executorService = Executors.newSingleThreadExecutor();
+    this.snapshotTableStore = new HashSet<>();
+  }
+
+  @Override
+  public void start(Offset offset) {
+    byte[] scnBytes = offset.get().get("scn");
+    String scn = scnBytes == null ? "" : Long.toString(Bytes.toLong(scnBytes));
+    LOG.info("scn : " + scn);
+
+    Configuration debeziumConf = Configuration.create()
+      .with("connector.class", OracleConnector.class.getName())
+      .with("offset.storage", ConstantOffsetBackingStore.class.getName())
+      .with("offset.storage.file.filename", scn)
+      .with("offset.flush.interval.ms", 1000)
+      /* begin connector properties */
+      .with("name", "delta")
+      .with("database.hostname", config.getHost())
+      .with("database.port", config.getPort())
+      .with("database.user", config.getUser())
+      .with("database.password", config.getPassword())
+      .with("database.dbname", config.getDbName())
+      .with("database.pdb.name", config.getPdbName())
+      .with("database.out.server.name", config.getOutServerName())
+      .with("database.history", DBSchemaHistory.class.getName())
+      // workaround fix for issue: https://groups.google.com/forum/#!topic/debezium/FrN5PFRFlmQ
+      .with("database.oracle.version", 11)
+      .with("database.server.name", "dummy") // this is the kafka topic for hosted debezium - it doesn't matter
+      .with("table.whitelist", config.getTableWhiteList())
+      .build();
+
+    DBSchemaHistory.deltaRuntimeContext = context;
+    ClassLoader oldCL = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+
+    try {
+      // Create the engine with this configuration ...
+      engine = EmbeddedEngine.create()
+        .using(debeziumConf)
+        .notifying(sourceRecord -> {
+          if (sourceRecord.value() == null) {
+            return;
+          }
+
+          Map<String, ?> sourceOffset = sourceRecord.sourceOffset();
+          Boolean snapshotCompleted = (Boolean) sourceOffset.get("snapshot_completed");
+          Map<String, byte[]> deltaOffset = new HashMap<>();
+
+          StructuredRecord val = Records.convert((Struct) sourceRecord.value());
+          StructuredRecord source = val.get("source");
+          String databaseName = config.getDbName();
+          String recordName = val.getSchema().getRecordName();
+          String[] parts = recordName.split("\\.");
+          String tableName = parts[1] + "_" + parts[2]; // schema_table as name
+          String transactionId = source.get("txId");
+          StructuredRecord before = val.get("before");
+          StructuredRecord after = val.get("after");
+          Long ingestTime = val.get("ts_ms");
+          Long logPosition;
+
+          if (snapshotCompleted == null) {
+            logPosition = source.get("scn");
+          } else {
+            logPosition = (Long) sourceOffset.get("scn");
+          }
+
+          deltaOffset.put("scn", Bytes.toBytes(logPosition));
+          Offset recordOffset = new Offset(deltaOffset);
+
+          DMLOperation op;
+          String opStr = val.get("op");
+
+          if ("c".equals(opStr)) {
+            op = DMLOperation.INSERT;
+            context.getMetrics().count("ddl.source.INSERT.count", 1);
+          } else if ("u".equals(opStr)) {
+            op = DMLOperation.UPDATE;
+            context.getMetrics().count("ddl.source.UPDATE.count", 1);
+          } else if ("d".equals(opStr)) {
+            op = DMLOperation.DELETE;
+            context.getMetrics().count("ddl.source.DELETE.count", 1);
+          } else if ("r".equals(opStr)) {
+            // create a normal INSERT DML event, only during snapshotting process that opStr is equal to 'r'
+            op = DMLOperation.INSERT;
+            context.getMetrics().count("ddl.source.Snapshot.INSERT.count", 1);
+          } else {
+            LOG.warn("Skipping unknown operation type '{}'", opStr);
+            context.getMetrics().count("ddl.source.OTHER.count", 1);
+            return;
+          }
+
+          if (!snapshotTableStore.contains(tableName)) {
+            LOG.info("Snapshotting for table " + tableName + " started.");
+            StructuredRecord key = Records.convert((Struct) sourceRecord.key());
+            List<Schema.Field> fields = key.getSchema().getFields();
+            List<String> primaryKeyFields = fields.stream().map(Schema.Field::getName).collect(Collectors.toList());
+            // this is a hack to get schema from either 'before' or 'after' field
+            Schema schema = op == DMLOperation.DELETE ? before.getSchema() : after.getSchema();
+
+            emitter.emit(DDLEvent.builder()
+                           .setDatabase(databaseName)
+                           .setOffset(recordOffset)
+                           .setOperation(DDLOperation.CREATE_TABLE)
+                           .setTable(tableName)
+                           .setSchema(schema)
+                           .setPrimaryKey(primaryKeyFields)
+                           .build());
+            snapshotTableStore.add(tableName);
+          }
+
+          if (op == DMLOperation.DELETE) {
+            emitter.emit(new DMLEvent(recordOffset, op, databaseName, tableName, before, transactionId, ingestTime));
+          } else {
+            emitter.emit(new DMLEvent(recordOffset, op, databaseName, tableName, after, transactionId, ingestTime));
+
+            if (snapshotCompleted != null) {
+              if (snapshotCompleted) {
+                LOG.info("Snapshotting for table " + tableName + " completed.");
+              } else {
+                LOG.debug("Snapshotting for table " + tableName + " was still undergoing.");
+              }
+            } else {
+              LOG.debug("New DML event " + opStr + " for table " + tableName);
+            }
+          }
+        })
+        .using((success, message, error) -> {
+          if (!success) {
+            LOG.error("Failed - {}", message, error);
+          }
+        })
+        .build();
+
+      executorService.submit(engine);
+    } finally {
+      Thread.currentThread().setContextClassLoader(oldCL);
+    }
+  }
+
+  @Override
+  public void stop() throws InterruptedException {
+    if (engine != null && engine.stop()) {
+      engine.await(1, TimeUnit.MINUTES);
+    }
+    executorService.shutdown();
+  }
+}

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleSourceRecordConsumer.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleSourceRecordConsumer.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.oracle;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.delta.api.DDLEvent;
+import io.cdap.delta.api.DDLOperation;
+import io.cdap.delta.api.DMLEvent;
+import io.cdap.delta.api.DMLOperation;
+import io.cdap.delta.api.EventEmitter;
+import io.cdap.delta.api.Offset;
+import io.cdap.delta.api.SourceTable;
+import io.debezium.connector.oracle.SourceInfo;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+import static io.cdap.delta.oracle.OracleConstantOffsetBackingStore.SNAPSHOT_COMPLETED;
+
+/**
+ * Source record consumer for Oracle DB.
+ */
+public class OracleSourceRecordConsumer implements Consumer<SourceRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(OracleSourceRecordConsumer.class);
+
+  private final String databaseName;
+  private final EventEmitter emitter;
+  // used to track the tables created or not
+  private final Set<SourceTable> snapshotTrackingTables;
+
+  public OracleSourceRecordConsumer(@Nonnull String databaseName, @Nonnull EventEmitter emitter) {
+    this.databaseName = databaseName;
+    this.emitter = emitter;
+    this.snapshotTrackingTables = new HashSet<>();
+  }
+
+  @Override
+  public void accept(SourceRecord sourceRecord) {
+    if (sourceRecord.value() == null) {
+      return;
+    }
+
+    Map<String, ?> sourceOffset = sourceRecord.sourceOffset();
+    Boolean snapshot = (Boolean) sourceOffset.get(SourceInfo.SNAPSHOT_KEY);
+    Boolean snapshotCompleted = (Boolean) sourceOffset.get(SNAPSHOT_COMPLETED);
+
+    Map<String, byte[]> deltaOffset = OracleConstantOffsetBackingStore.serializeOffsets(sourceRecord);
+    StructuredRecord val = Records.convert((Struct) sourceRecord.value());
+    StructuredRecord source = val.get("source");
+    String recordName = val.getSchema().getRecordName();
+    String tableName  = recordName.split("\\.")[2];
+    String transactionId = source.get("txId");
+    StructuredRecord before = val.get("before");
+    StructuredRecord after = val.get("after");
+    Long ingestTime = val.get("ts_ms");
+    Offset recordOffset = new Offset(deltaOffset);
+    SourceTable table = new SourceTable(databaseName, tableName);
+
+    DMLOperation op;
+    String opStr = val.get("op");
+    if ("c".equals(opStr) || "r".equals(opStr)) {
+      op = DMLOperation.INSERT;
+    } else if ("u".equals(opStr)) {
+      op = DMLOperation.UPDATE;
+    } else if ("d".equals(opStr)) {
+      op = DMLOperation.DELETE;
+    } else {
+      LOG.warn("Skipping unknown operation type '{}'", opStr);
+      return;
+    }
+
+    // send the ddl event iff it was not in tracking before and it was marked as under snapshotting
+    if (!snapshotTrackingTables.contains(table) && Boolean.TRUE.equals(snapshot)) {
+      LOG.info("Snapshotting for table {} in database {} started", tableName, databaseName);
+      StructuredRecord key = Records.convert((Struct) sourceRecord.key());
+      List<Schema.Field> fields = key.getSchema().getFields();
+      List<String> primaryKeyFields = fields.stream().map(Schema.Field::getName).collect(Collectors.toList());
+      // this is a hack to get schema from either 'before' or 'after' field
+      Schema schema = op == DMLOperation.DELETE ? before.getSchema() : after.getSchema();
+
+      emitter.emit(DDLEvent.builder()
+                     .setDatabase(databaseName)
+                     .setOffset(recordOffset)
+                     .setOperation(DDLOperation.CREATE_TABLE)
+                     .setTable(tableName)
+                     .setSchema(schema)
+                     .setPrimaryKey(primaryKeyFields)
+                     .build());
+      snapshotTrackingTables.add(table);
+    }
+
+    if (op == DMLOperation.DELETE) {
+      emitter.emit(new DMLEvent(recordOffset, op, databaseName, tableName, before, transactionId, ingestTime));
+    } else {
+      emitter.emit(new DMLEvent(recordOffset, op, databaseName, tableName, after, transactionId, ingestTime));
+
+
+      if (Boolean.TRUE.equals(snapshotCompleted)) {
+        LOG.info("Snapshotting for table {} in database {} completed", tableName, databaseName);
+      }
+    }
+  }
+}

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/Records.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/Records.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.oracle;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.debezium.connector.oracle.OracleValueConverters;
+import io.debezium.data.VariableScaleDecimal;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utilities for converting Records and Schemas.
+ */
+public class Records {
+
+  private Records() {
+    // no-op
+  }
+
+  /**
+   * Return the schema of a table.
+   *
+   * @param table
+   * @param converters
+   * @return
+   */
+  public static Schema getSchema(Table table, OracleValueConverters converters) {
+    List<Schema.Field> fields = new ArrayList<>(table.columns().size());
+    for (Column column : table.columns()) {
+      fields.add(Schema.Field.of(column.name(), convert(converters.schemaBuilder(column).build())));
+    }
+    return Schema.recordOf(table.id().table(), fields);
+  }
+
+  /**
+   * Convert a Debezium row, represented as a Kafka Connect Struct, into a CDAP StructuredRecord.
+   *
+   * TODO: investigate logical types
+   *
+   * @param struct
+   * @return
+   */
+  public static StructuredRecord convert(Struct struct) {
+    Schema schema = convert(struct.schema());
+    schema = schema.isNullable() ? schema.getNonNullable() : schema;
+
+    StructuredRecord.Builder builder = StructuredRecord.builder(schema);
+    for (Field field : struct.schema().fields()) {
+      builder.set(field.name(), convert(field.schema(), struct.get(field.name())));
+    }
+    return builder.build();
+  }
+
+  private static Object convert(org.apache.kafka.connect.data.Schema schema, Object val) {
+    if (val == null) {
+      return null;
+    }
+    switch (schema.type()) {
+      case BOOLEAN:
+      case BYTES:
+      case STRING:
+      case INT32:
+      case INT64:
+      case FLOAT32:
+      case FLOAT64:
+        return val;
+      case INT8:
+        return new Integer((Byte) val);
+      case INT16:
+        return new Integer((Short) val);
+      case ARRAY:
+        return ((List<?>) val).stream()
+          .map(o -> convert(schema.valueSchema(), o))
+          .collect(Collectors.toList());
+      case MAP:
+        return ((Map<?, ?>) val).entrySet().stream()
+          .collect(Collectors.toMap(
+            mapKey -> convert(schema.keySchema(), mapKey),
+            mapVal -> convert(schema.valueSchema(), mapVal)));
+      case STRUCT:
+        return convert((Struct) val);
+    }
+    // should never happen, all values are listed above
+    throw new IllegalStateException(String.format("Kafka type '%s' is not supported.", schema.type()));
+  }
+
+  /**
+   * Converts a schema from Debezium, which uses Kafka Connect schemas, into a CDAP schema.
+   *
+   * @param schema
+   * @return
+   */
+  public static Schema convert(org.apache.kafka.connect.data.Schema schema) {
+    Schema converted;
+    switch (schema.type()) {
+      case BOOLEAN:
+        converted = Schema.of(Schema.Type.BOOLEAN);
+        break;
+      case BYTES:
+        converted = Schema.of(Schema.Type.BYTES);
+        break;
+      case STRING:
+        converted = Schema.of(Schema.Type.STRING);
+        break;
+      case INT8:
+      case INT16:
+      case INT32:
+        converted = Schema.of(Schema.Type.INT);
+        break;
+      case INT64:
+        converted = Schema.of(Schema.Type.LONG);
+        break;
+      case FLOAT32:
+        converted = Schema.of(Schema.Type.FLOAT);
+        break;
+      case FLOAT64:
+        converted = Schema.of(Schema.Type.DOUBLE);
+        break;
+      case ARRAY:
+        converted = Schema.arrayOf(convert(schema.valueSchema()));
+        break;
+      case MAP:
+        converted = Schema.mapOf(convert(schema.keySchema()), convert(schema.valueSchema()));
+        break;
+      case STRUCT:
+        if (schema.name().equals(VariableScaleDecimal.class.getName())) {
+          converted = Schema.of(Schema.Type.DOUBLE);
+          break;
+        }
+        List<Field> fields = schema.fields();
+        List<Schema.Field> cdapFields = new ArrayList<>(fields.size());
+        for (Field field : fields) {
+          cdapFields.add(Schema.Field.of(field.name(), convert(field.schema())));
+        }
+        converted = Schema.recordOf(schema.name(), cdapFields);
+        break;
+      default:
+        // should never happen, all values are listed above
+        throw new IllegalStateException(String.format("Kafka type '%s' is not supported.", schema.type()));
+    }
+    if (schema.isOptional()) {
+      return Schema.nullableOf(converted);
+    }
+    return converted;
+  }
+}

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/Records.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/Records.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 /**
  * Utilities for converting Records and Schemas.
  */
-public class Records {
+public final class Records {
 
   private Records() {
     // no-op

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
   <version>0.1.0-SNAPSHOT</version>
   <modules>
     <module>mysql-delta-plugins</module>
+    <module>oracle-delta-plugins</module>
     <module>delta-plugins-common</module>
   </modules>
   <name>Database Delta plugins</name>


### PR DESCRIPTION
This is an initial pr for adding oracle delta plugins. Debezium does not emit table schema change or table drop DDL event. Even during the initial snapshotting process, the first event that debezium engine got is an DML event with 'R' operation. The workaround for that is to identify if the table is under snapshotting the first time and create DDL event and DML event at same time, and the rest of 'R' event will be treated as normal insert DML event. 

JIRA link: https://issues.cask.co/browse/PLUGIN-104

Testing:
Verified it can generating DDL event and DML event as expected. 
Tested Offset loading, it works as expected, after restarts the pipeline, worker was able to pick up where it left without snappshotting from the beginning. 