### PR TITLE
Integrate event filtering into OracleSourceRecordConsumer.

### DIFF
--- a/delta-plugins-common/src/main/java/io/cdap/delta/common/BlacklistEventSet.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/common/BlacklistEventSet.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.common;
+
+import io.cdap.delta.api.DDLOperation;
+import io.cdap.delta.api.DMLOperation;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Defines a set of DML event blacklist and a set of DDL event blacklist.
+ */
+public class BlacklistEventSet {
+  private final Set<DMLOperation> dmlBlacklist;
+  private final Set<DDLOperation> ddlBlacklist;
+
+  public BlacklistEventSet(Set<DMLOperation> dmlBlacklist, Set<DDLOperation> ddlBlacklist) {
+    this.dmlBlacklist = Collections.unmodifiableSet(new HashSet<>(dmlBlacklist));
+    this.ddlBlacklist = Collections.unmodifiableSet(new HashSet<>(ddlBlacklist));
+  }
+
+  /**
+   * @return set of DML operations that should always be ignored.
+   */
+  public Set<DMLOperation> getDmlBlacklist() {
+    return dmlBlacklist;
+  }
+
+  /**
+   * @return set of DDL operations that should always be ignored
+   */
+  public Set<DDLOperation> getDdlBlacklist() {
+    return ddlBlacklist;
+  }
+}

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleDeltaSource.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleDeltaSource.java
@@ -57,8 +57,7 @@ public class OracleDeltaSource implements DeltaSource {
   @Override
   public EventReader createReader(EventReaderDefinition definition, DeltaSourceContext context,
                                   EventEmitter eventEmitter) {
-    // TODO: incorporate with list of tables into event reader.
-    return new OracleEventReader(conf, context, eventEmitter);
+    return new OracleEventReader(conf, context, eventEmitter, definition);
   }
 
   @Override

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
@@ -17,8 +17,6 @@
 package io.cdap.delta.oracle;
 
 import io.cdap.cdap.api.common.Bytes;
-import io.cdap.delta.api.DDLOperation;
-import io.cdap.delta.api.DMLOperation;
 import io.cdap.delta.api.DeltaSourceContext;
 import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.EventReader;
@@ -35,9 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -82,18 +78,9 @@ public class OracleEventReader implements EventReader {
         sourceTable -> {
           String schema = sourceTable.getSchema();
           String table = sourceTable.getTable();
-          return (schema == null ? table : schema + "." + table).toUpperCase();
+          return schema == null ? table : schema + "." + table;
         },
-        sourceTable -> {
-          // union pipeline level blacklist and the table specific blacklist for DDL/DML
-          Set<DDLOperation> mergedDdlBlacklist = new HashSet<>();
-          mergedDdlBlacklist.addAll(sourceTable.getDdlBlacklist());
-          mergedDdlBlacklist.addAll(definition.getDdlBlacklist());
-          Set<DMLOperation> mergedDmlBlacklist = new HashSet<>();
-          mergedDmlBlacklist.addAll(sourceTable.getDmlBlacklist());
-          mergedDmlBlacklist.addAll(definition.getDmlBlacklist());
-          return new BlacklistEventSet(mergedDmlBlacklist, mergedDdlBlacklist);
-        }));
+        sourceTable -> new BlacklistEventSet(sourceTable.getDmlBlacklist(), sourceTable.getDdlBlacklist())));
 
     Configuration.Builder builder = Configuration.create()
       .with("connector.class", OracleConnector.class.getName())

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleSourceRecordConsumer.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleSourceRecordConsumer.java
@@ -75,10 +75,10 @@ public class OracleSourceRecordConsumer implements Consumer<SourceRecord> {
     StructuredRecord val = Records.convert((Struct) sourceRecord.value());
     StructuredRecord source = val.get("source");
     String recordName = val.getSchema().getRecordName();
+    // the record name will always be like this: [db.server.name].[schema].[table].Envelope
     if (recordName == null) {
       return; // safety check to avoid NPE
     }
-    // the splits will be returned like [db.server.name].[schema].[table].Envelope
     String[] splits = recordName.split("\\.");
     String schemaName = splits[1];
     String tableName  = splits[2];

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleSourceRecordConsumer.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleSourceRecordConsumer.java
@@ -26,6 +26,7 @@ import io.cdap.delta.api.DMLOperation;
 import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.Offset;
 import io.cdap.delta.api.SourceTable;
+import io.cdap.delta.common.BlacklistEventSet;
 import io.debezium.connector.oracle.SourceInfo;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -48,12 +49,15 @@ public class OracleSourceRecordConsumer implements Consumer<SourceRecord> {
 
   private final String databaseName;
   private final EventEmitter emitter;
+  private final Map<String, BlacklistEventSet> sourceTableBlacklistEventMap;
   // used to track the tables created or not
   private final Set<SourceTable> snapshotTrackingTables;
 
-  public OracleSourceRecordConsumer(String databaseName, EventEmitter emitter) {
+  public OracleSourceRecordConsumer(String databaseName, EventEmitter emitter,
+                                    Map<String, BlacklistEventSet> sourceTableBlacklistEventMap) {
     this.databaseName = databaseName;
     this.emitter = emitter;
+    this.sourceTableBlacklistEventMap = sourceTableBlacklistEventMap;
     this.snapshotTrackingTables = new HashSet<>();
   }
 
@@ -71,7 +75,16 @@ public class OracleSourceRecordConsumer implements Consumer<SourceRecord> {
     StructuredRecord val = Records.convert((Struct) sourceRecord.value());
     StructuredRecord source = val.get("source");
     String recordName = val.getSchema().getRecordName();
-    String tableName  = recordName.split("\\.")[2];
+    if (recordName == null) {
+      return; // safety check to avoid NPE
+    }
+    String schemaName = recordName.split("\\.")[1].toUpperCase();
+    String tableName  = recordName.split("\\.")[2].toUpperCase();
+    String sourceTableId = schemaName + "." + tableName;
+    if (sourceTableBlacklistEventMap.get(sourceTableId) == null) {
+      // shouldn't happen
+      return;
+    }
     String transactionId = source.get("txId");
     StructuredRecord before = val.get("before");
     StructuredRecord after = val.get("after");
@@ -100,8 +113,12 @@ public class OracleSourceRecordConsumer implements Consumer<SourceRecord> {
         return;
     }
 
-    // send the ddl event iff it was not in tracking before and it was marked as under snapshotting
-    if (!snapshotTrackingTables.contains(table) && Boolean.TRUE.equals(snapshot)) {
+    // send the ddl event iff all the following conditions have been met:
+    // 1. CREATE_TABLE DDL op is not blacklisted
+    // 2. it was not in tracking before
+    // 3. it was marked as under snapshotting
+    if (!sourceTableBlacklistEventMap.get(sourceTableId).getDdlBlacklist().contains(DDLOperation.CREATE_TABLE) &&
+      !snapshotTrackingTables.contains(table) && Boolean.TRUE.equals(snapshot)) {
       LOG.info("Snapshotting for table {} in database {} started", tableName, databaseName);
       StructuredRecord key = Records.convert((Struct) sourceRecord.key());
       List<Schema.Field> fields = key.getSchema().getFields();
@@ -118,6 +135,11 @@ public class OracleSourceRecordConsumer implements Consumer<SourceRecord> {
                      .setPrimaryKey(primaryKeyFields)
                      .build());
       snapshotTrackingTables.add(table);
+    }
+
+    if (sourceTableBlacklistEventMap.get(sourceTableId).getDmlBlacklist().contains(op)) {
+      // do nothing due to this DML op has been blacklisted
+      return;
     }
 
     if (op == DMLOperation.DELETE) {


### PR DESCRIPTION
This PR is for integrating event filtering into Oracle-delta-plugin. The filtering is focused on DDL/DML operation filtering. 

Jira link: https://issues.cask.co/browse/CDAP-16274