### PR TITLE
Feature/cdap 16306 load x stream jar for oracle at runtime

### DIFF
--- a/oracle-delta-plugins/pom.xml
+++ b/oracle-delta-plugins/pom.xml
@@ -33,13 +33,6 @@
       <artifactId>debezium-connector-oracle</artifactId>
       <version>${debezium.version}</version>
     </dependency>
-    <!-- TODO: load xstream dependency and bind with the plugin given by user -->
-    <dependency>
-      <groupId>com.oracle.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>12.0.1.0</version>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>io.cdap.delta</groupId>
       <artifactId>delta-plugins-common</artifactId>
@@ -73,6 +66,24 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <!-- newly added test dependency     -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14.1</version>
+        <configuration>
+          <argLine>-Xmx512m</argLine>
+          <systemPropertyVariables>
+            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+          </systemPropertyVariables>
+          <includes>
+            <include>**/*TestSuite.java</include>
+            <include>**/Test*.java</include>
+            <include>**/*Test.java</include>
+            <include>**/*TestCase.java</include>
+          </includes>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/oracle-delta-plugins/pom.xml
+++ b/oracle-delta-plugins/pom.xml
@@ -67,24 +67,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- newly added test dependency     -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
-        <configuration>
-          <argLine>-Xmx512m</argLine>
-          <systemPropertyVariables>
-            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-          </systemPropertyVariables>
-          <includes>
-            <include>**/*TestSuite.java</include>
-            <include>**/Test*.java</include>
-            <include>**/*Test.java</include>
-            <include>**/*TestCase.java</include>
-          </includes>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConfig.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleConfig.java
@@ -49,8 +49,8 @@ public class OracleConfig extends PluginConfig {
   @Description("Name of the JDBC plugin to use.")
   private String jdbcPluginName;
 
-  // TODO: implement the proper way load JDBC from remote path
-  @Description("Path to load JDBC native libraries from local.")
+  // TODO: implement the proper way load oracle instant client libraries from remote path
+  @Description("Path to load oracle instant client libraries from local.")
   private String libPath;
 
   @Nullable

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
@@ -74,7 +74,7 @@ public class OracleEventReader implements EventReader {
       fieldSysPath.setAccessible(true);
       fieldSysPath.set(null, null);
     } catch (Exception e) {
-      throw new RuntimeException("Unable to load jdbc native libraries.");
+      throw new RuntimeException(String.format("Unable to load jdbc native libraries: %s", e.getMessage()), e);
     }
 
     // This is a hacky way to load xstream jar. What we do here is using URLClassLoader reflection to invoke
@@ -91,7 +91,7 @@ public class OracleEventReader implements EventReader {
       method.setAccessible(true);
       method.invoke(classLoader, url);
     } catch (Exception e) {
-      throw new RuntimeException("Unable to load xstream.jar to class loader.");
+      throw new RuntimeException(String.format("Unable to load xstream.jar to class loader: %s", e.getMessage()), e);
     }
 
     Map<String, SourceTable> sourceTableMap = definition.getTables().stream().collect(

--- a/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
+++ b/oracle-delta-plugins/src/main/java/io/cdap/delta/oracle/OracleEventReader.java
@@ -31,7 +31,11 @@ import io.debezium.embedded.EmbeddedEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -73,6 +77,23 @@ public class OracleEventReader implements EventReader {
       throw new RuntimeException("Unable to load jdbc native libraries.");
     }
 
+    // This is a hacky way to load xstream jar. What we do here is using URLClassLoader reflection to invoke
+    // protected 'addURL(URL url)' method to bind xstream jar into our current class loader which is a
+    // PluginClassLoader. The reason why this is hacky is that Java 9+ will warn that
+    // URLClassLoader.class.getDeclaredMethod("addURL", URL.class) is an illegal use of reflection.
+    // TODO: CDAP-16311 Have a proper way to register user jars into CDAP
+    ClassLoader classLoader = getClass().getClassLoader();
+    try {
+      String jarPath = config.getLibPath() + "/xstreams.jar";
+      File file = new File(jarPath);
+      URL url = file.toURI().toURL();
+      Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
+      method.setAccessible(true);
+      method.invoke(classLoader, url);
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to load xstream.jar to class loader.");
+    }
+
     Map<String, SourceTable> sourceTableMap = definition.getTables().stream().collect(
       Collectors.toMap(
         t -> {
@@ -108,7 +129,7 @@ public class OracleEventReader implements EventReader {
 
     DBSchemaHistory.deltaRuntimeContext = context;
     ClassLoader oldCL = Thread.currentThread().getContextClassLoader();
-    Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+    Thread.currentThread().setContextClassLoader(classLoader);
 
     try {
       // Create the engine with this configuration ...

--- a/oracle-delta-plugins/widgets/oracle-cdcSource.json
+++ b/oracle-delta-plugins/widgets/oracle-cdcSource.json
@@ -59,7 +59,7 @@
         },
         {
           "name": "libPath",
-          "label": "Oracle JDBC Native Library Path",
+          "label": "Oracle Instant Client Library Path",
           "widget-type": "textbox"
         }
       ]


### PR DESCRIPTION
1. Change the name of the lib path to "Oracle Instance Client", because when customer have a golden gate license, customer will download the "Oracle Instance Client" which contains jdbc.jar, jdbc native libraries and xstream.jar. In this case, we will just need to have the path for unzipped "Oracle Instant Client".
2. Use a hacky way for now to load xtream.jar into oracle plugin class loader AND add a TODO action item to improve that in the future. In addition, remove the xstream maven dependency so that we can unblock the maven build.