### PR TITLE
CDAP-16262 Add scale and precision support for sql-server source plugin.

### DIFF
--- a/delta-plugins-common/src/main/java/io/cdap/delta/common/Records.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/common/Records.java
@@ -26,6 +26,7 @@ import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -102,9 +103,24 @@ public class Records {
     schema = schema.isNullable() ? schema.getNonNullable() : schema;
 
     StructuredRecord.Builder builder = StructuredRecord.builder(schema);
-    for (Field field : struct.schema().fields()) {
-      builder.set(field.name(), convert(field.schema(), struct.get(field.name())));
+    if (schema.getFields() == null) {
+      return builder.build();
     }
+
+    for (Schema.Field field : schema.getFields()) {
+      String fieldName = field.getName();
+      Field debeziumField = struct.schema().field(fieldName);
+      Object val = convert(debeziumField.schema(), struct.get(fieldName));
+      Schema.LogicalType logicalType = field.getSchema().getLogicalType();
+      // TODO: This is a special handling for DECIMAL logical type, further logical types like DATE, TIMESTAMP, etc
+      // will be supported later on.
+      if (Schema.LogicalType.DECIMAL == logicalType) {
+        builder.setDecimal(fieldName, (BigDecimal) val);
+      } else {
+        builder.set(fieldName, val);
+      }
+    }
+
     return builder.build();
   }
 

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableAssessor.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableAssessor.java
@@ -31,11 +31,14 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Sql server table assessor
  */
 public class SqlServerTableAssessor implements TableAssessor<TableDetail> {
+  static final String COLUMN_LENGTH = "COLUMN_LENGTH";
+  static final String SCALE = "SCALE";
 
   @Override
   public TableAssessment assess(TableDetail tableDetail) {
@@ -80,8 +83,16 @@ public class SqlServerTableAssessor implements TableAssessor<TableDetail> {
 
       case Types.NUMERIC:
       case Types.DECIMAL:
-        // TODO: CDAP-16262 Add scale and precision to ColumnDetail to correctly determine the schema type
-        schema = Schema.of(Schema.Type.DOUBLE);
+        Map<String, String> properties = detail.getProperties();
+        // For numeric/decimal columns, this 'COLUMN_LENGTH' represents the precision
+        int precision = Integer.parseInt(properties.get(COLUMN_LENGTH));
+        int scale = Integer.parseInt(properties.get(SCALE));
+
+        // According to the official sql server doc, precision must be a value from 1 to 38 and scale must
+        // be a value from 0 to precision. Since the scale is always greater or equal to 0, the precision here
+        // is always equal to the number of significant digits, we can just reuse the precision to form
+        // cdap decimal logical type.
+        schema = Schema.decimalOf(precision, scale);
         break;
 
       case Types.DOUBLE:

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableRegistry.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableRegistry.java
@@ -37,8 +37,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -134,10 +136,14 @@ public class SqlServerTableRegistry implements TableRegistry {
     String schemaName = null;
     try (ResultSet columnResults = dbMeta.getColumns(db, null, table, null)) {
       while (columnResults.next()) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(SqlServerTableAssessor.COLUMN_LENGTH, columnResults.getString("COLUMN_SIZE"));
+        properties.put(SqlServerTableAssessor.SCALE, columnResults.getString("DECIMAL_DIGITS"));
         schemaName = columnResults.getString("TABLE_SCHEM");
         columns.add(new ColumnDetail(columnResults.getString("COLUMN_NAME"),
                                      JDBCType.valueOf(columnResults.getInt("DATA_TYPE")),
-                                     columnResults.getBoolean("NULLABLE")));
+                                     columnResults.getBoolean("NULLABLE"),
+                                     properties));
       }
     }
     if (columns.isEmpty()) {


### PR DESCRIPTION
When we create table using NUMERIC[p, s] or DECIMAL[p, s] SQL-Server type, in sql-server assessor, it will be mapped to JDBC type NUMERIC and DECIMAL, sql-server assessor will read the precision/scale and convert to CDAP Decimal logical type. 

When debezium returns events back to us, the default schema type for NUMERIC/DECIMAL is called ''org.apache.kafka.connect.data.Decimal", the sql-server consumer will parse the precision/scale out and form the CDAP Decimal logical type. Again, the val type return by debezium is Java BigDecimal, we can reuse that. So the target should be able to understand the Decimal Logical type and deal with the BigDecimal val. 