### PR TITLE
CDAP-16346 restart the event reader if it fails

### DIFF
--- a/delta-plugins-common/src/main/java/io/cdap/delta/common/NotifyingCompletionCallback.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/common/NotifyingCompletionCallback.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.common;
+
+import io.cdap.delta.api.DeltaSourceContext;
+import io.cdap.delta.api.ReplicationError;
+import io.debezium.embedded.EmbeddedEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Notifies the app and updates the replication state if the embedded engine fails.
+ */
+public class NotifyingCompletionCallback implements EmbeddedEngine.CompletionCallback {
+  private static final Logger LOG = LoggerFactory.getLogger(NotifyingCompletionCallback.class);
+  private final DeltaSourceContext context;
+
+  public NotifyingCompletionCallback(DeltaSourceContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public void handle(boolean success, String message, Throwable error) {
+    if (!success) {
+      // ignore the message, since it's a generic message unrelated to the cause
+      // "Failed to start connector with invalid configuration (see logs for actual errors)".
+      try {
+        context.setError(new ReplicationError(error));
+      } catch (IOException e) {
+        LOG.warn("Failed to update in the state store that the source is having issues", e);
+      }
+      context.notifyFailed(error);
+    }
+  }
+}

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
@@ -27,6 +27,7 @@ import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.EventReader;
 import io.cdap.delta.api.Offset;
 import io.cdap.delta.common.DBSchemaHistory;
+import io.cdap.delta.common.NotifyingCompletionCallback;
 import io.cdap.delta.common.Records;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnector;
@@ -269,11 +270,7 @@ public class MySqlEventReader implements EventReader {
             emitter.emit(builder.setRow(after).build());
           }
         })
-        .using((success, message, error) -> {
-          if (!success) {
-            LOG.error("Failed - {}", message, error);
-          }
-        })
+        .using(new NotifyingCompletionCallback(context))
         .build();
       executorService.submit(engine);
     } finally {


### PR DESCRIPTION
Changed the event reader so that it notifies the app if the
Debezium enginer fails for some reason. This will cause the app
to restart the reader from the last committed offset.