### PR TITLE
CDAP-16378 Load MySQL JDBC driver class into MYSQL Delta Source.

### DIFF
--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
@@ -94,4 +94,8 @@ public class MySqlConfig extends PluginConfig {
   public String getJdbcPluginName() {
     return jdbcPluginName;
   }
+
+  public String getJDBCPluginId() {
+    return String.format("%s.%s.%s", "mysqlsource", "jbdc", jdbcPluginName);
+  }
 }

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlDeltaSource.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlDeltaSource.java
@@ -49,7 +49,9 @@ public class MySqlDeltaSource implements DeltaSource {
 
   @Override
   public void configure(Configurer configurer) {
-    // no-op
+    // add MySql JDBC Plugin usage at configure time
+    configurer.usePluginClass("jdbc", conf.getJdbcPluginName(), conf.getJDBCPluginId(),
+                              PluginProperties.builder().build());
   }
 
   @Override
@@ -62,7 +64,7 @@ public class MySqlDeltaSource implements DeltaSource {
   @Override
   public TableRegistry createTableRegistry(Configurer configurer) {
     Class<? extends Driver> jdbcDriverClass = configurer.usePluginClass("jdbc", conf.getJdbcPluginName(),
-                                                                        "targetDriver",
+                                                                        conf.getJDBCPluginId(),
                                                                         PluginProperties.builder().build());
     if (jdbcDriverClass == null) {
       throw new IllegalArgumentException("JDBC plugin " + conf.getJdbcPluginName() + " not found.");

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
@@ -73,8 +73,8 @@ public class MySqlEventReader implements EventReader {
   public void start(Offset offset) {
     // load mysql jdbc driver into class loader here and use this loaded jdbc class and class loader to set static
     // variable 'connectionFactory' in MySqlJdbcContext and static variable 'jdbcClassLoader' in MySqlValueConverters.
-    // so far, this is a needed hacky solution for us to solve the problem of not packing mysql-jdbc jar for MySql
-    // delta plugin in CDAP.
+    // note that, this is a short-term hacky solution for us to solve the problem of excluding mysql-jdbc jar from MySql
+    // delta plugin's dependencies in CDAP.
     Class<? extends Driver> jdbcDriverClass = context.loadPluginClass(config.getJDBCPluginId());
     MySqlJdbcContext.connectionFactory = JdbcConnection.patternBasedFactory(MySqlJdbcContext.MYSQL_CONNECTION_URL,
                                                                             jdbcDriverClass.getName(),

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -745,8 +745,10 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withDependents(DATABASE_WHITELIST_NAME)
     .withDescription("Flag specifying whether built-in tables should be ignored.");
 
-  // This is the only changed from the original file.
-  // We basically just delete the usage of 'com.mysql.cj.jdbc.Driver' class
+  /**
+   * ===================== This is a diff from the original file ===========================
+   * We basically just delete the usage of 'com.mysql.cj.jdbc.Driver' class.
+   */
   public static final Field JDBC_DRIVER = Field.create("database.jdbc.driver")
     .withDisplayName("Jdbc Driver Class Name")
     .withType(Type.CLASS)

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -1,0 +1,1388 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.config.EnumeratedValue;
+import io.debezium.config.Field;
+import io.debezium.config.Field.ValidationOutput;
+import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.jdbc.JdbcValueConverters;
+import io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode;
+import io.debezium.jdbc.TemporalPrecisionMode;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Tables.TableFilter;
+import io.debezium.relational.ddl.DdlParser;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.relational.history.KafkaDatabaseHistory;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.Random;
+
+/**
+ * The configuration properties.
+ */
+public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
+
+  /**
+   * The set of predefined BigIntUnsignedHandlingMode options or aliases.
+   */
+  public enum BigIntUnsignedHandlingMode implements EnumeratedValue {
+    /**
+     * Represent {@code BIGINT UNSIGNED} values as precise {@link BigDecimal} values, which are
+     * represented in change events in a binary form. This is precise but difficult to use.
+     */
+    PRECISE("precise"),
+
+    /**
+     * Represent {@code BIGINT UNSIGNED} values as precise {@code long} values. This may be less precise
+     * but is far easier to use.
+     */
+    LONG("long");
+
+    private final String value;
+
+    BigIntUnsignedHandlingMode(String value) {
+      this.value = value;
+    }
+
+    @Override public String getValue() {
+      return value;
+    }
+
+    public BigIntUnsignedMode asBigIntUnsignedMode() {
+      switch (this) {
+        case LONG:
+          return BigIntUnsignedMode.LONG;
+        case PRECISE:
+        default:
+          return BigIntUnsignedMode.PRECISE;
+      }
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @return the matching option, or null if no match is found
+     */
+    public static BigIntUnsignedHandlingMode parse(String value) {
+      if (value == null) {
+        return null;
+      }
+      value = value.trim();
+      for (BigIntUnsignedHandlingMode option : BigIntUnsignedHandlingMode.values()) {
+        if (option.getValue().equalsIgnoreCase(value)) {
+          return option;
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @param defaultValue the default value; may be null
+     * @return the matching option, or null if no match is found and the non-null default is invalid
+     */
+    public static BigIntUnsignedHandlingMode parse(String value, String defaultValue) {
+      BigIntUnsignedHandlingMode mode = parse(value);
+      if (mode == null && defaultValue != null) {
+        mode = parse(defaultValue);
+      }
+      return mode;
+    }
+  }
+
+  /**
+   * The set of predefined SnapshotMode options or aliases.
+   */
+  public enum SnapshotMode implements EnumeratedValue {
+
+    /**
+     * Perform a snapshot when it is needed.
+     */
+    WHEN_NEEDED("when_needed", true),
+
+    /**
+     * Perform a snapshot only upon initial startup of a connector.
+     */
+    INITIAL("initial", true),
+
+    /**
+     * Perform a snapshot of only the database schemas (without data) and then begin reading the binlog.
+     * This should be used with care, but it is very useful when the change event consumers need only the changes
+     * from the point in time the snapshot is made (and doesn't care about any state or changes prior to this point).
+     */
+    SCHEMA_ONLY("schema_only", false),
+
+    /**
+     * Perform a snapshot of only the database schemas (without data) and then begin reading the binlog at the current
+     * binlog position. This can be used for recovery only if the connector has existing offsets and the
+     * database.history.kafka.topic does not exist (deleted).
+     * This recovery option should be used with care as it assumes there have been no schema changes since the connector
+     * last stopped, otherwise some events during the gap may be processed with an incorrect schema and corrupted.
+     */
+    SCHEMA_ONLY_RECOVERY("schema_only_recovery", false),
+
+    /**
+     * Never perform a snapshot and only read the binlog. This assumes the binlog contains all the history of those
+     * databases and tables that will be captured.
+     */
+    NEVER("never", false),
+
+    /**
+     * Perform a snapshot and then stop before attempting to read the binlog.
+     */
+    INITIAL_ONLY("initial_only", true);
+
+    private final String value;
+    private final boolean includeData;
+
+    SnapshotMode(String value, boolean includeData) {
+      this.value = value;
+      this.includeData = includeData;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    /**
+     * Whether this snapshotting mode should include the actual data or just the
+     * schema of captured tables.
+     */
+    public boolean includeData() {
+      return includeData;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @return the matching option, or null if no match is found
+     */
+    public static SnapshotMode parse(String value) {
+      if (value == null) {
+        return null;
+      }
+      value = value.trim();
+      for (SnapshotMode option : SnapshotMode.values()) {
+        if (option.getValue().equalsIgnoreCase(value)) {
+          return option;
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @param defaultValue the default value; may be null
+     * @return the matching option, or null if no match is found and the non-null default is invalid
+     */
+    public static SnapshotMode parse(String value, String defaultValue) {
+      SnapshotMode mode = parse(value);
+      if (mode == null && defaultValue != null) {
+        mode = parse(defaultValue);
+      }
+      return mode;
+    }
+  }
+
+  /**
+   * Class for snapshot new tables.
+   */
+  public enum SnapshotNewTables implements EnumeratedValue {
+    /**
+     * Do not snapshot new tables
+     */
+    OFF("off"),
+
+    /**
+     * Snapshot new tables in parallel to normal binlog reading.
+     */
+    PARALLEL("parallel");
+
+    private final String value;
+
+    SnapshotNewTables(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @return the matching option, or null if no match is found
+     */
+    public static SnapshotNewTables parse(String value) {
+      if (value == null) {
+        return null;
+      }
+      value = value.trim();
+      for (SnapshotNewTables option : SnapshotNewTables.values()) {
+        if (option.getValue().equalsIgnoreCase(value)) {
+          return option;
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @param defaultValue the default value; may be null
+     * @return the matching option, or null if no match is found and the non-null default is invalid
+     */
+    public static SnapshotNewTables parse(String value, String defaultValue) {
+      SnapshotNewTables snapshotNewTables = parse(value);
+      if (snapshotNewTables == null && defaultValue != null) {
+        snapshotNewTables = parse(defaultValue);
+      }
+      return snapshotNewTables;
+    }
+  }
+
+  /**
+   * The set of predefined Snapshot Locking Mode options.
+   */
+  public enum SnapshotLockingMode implements EnumeratedValue {
+
+    /**
+     * This mode will block all writes for the entire duration of the snapshot.
+     *
+     * Replaces deprecated configuration option snapshot.locking.minimal with a value of false.
+     */
+    EXTENDED("extended"),
+
+    /**
+     * The connector holds the global read lock for just the initial portion of the snapshot while the connector reads
+     * the database schemas and other metadata. The remaining work in a snapshot involves selecting all rows from each
+     * table, and this can be done in a consistent fashion using the REPEATABLE READ transaction even when the global
+     * read lock is no longer held and while other MySQL clients are updating the database.
+     *
+     * Replaces deprecated configuration option snapshot.locking.minimal with a value of true.
+     */
+    MINIMAL("minimal"),
+
+    /**
+     * This mode will avoid using ANY table locks during the snapshot process.  This mode can only be used with
+     * SnapShotMode set to schema_only or schema_only_recovery.
+     */
+    NONE("none");
+
+    private final String value;
+
+    SnapshotLockingMode(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @return the matching option, or null if no match is found
+     */
+    public static SnapshotLockingMode parse(String value) {
+      if (value == null) {
+        return null;
+      }
+      value = value.trim();
+      for (SnapshotLockingMode option : SnapshotLockingMode.values()) {
+        if (option.getValue().equalsIgnoreCase(value)) {
+          return option;
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @param defaultValue the default value; may be null
+     * @return the matching option, or null if no match is found and the non-null default is invalid
+     */
+    public static SnapshotLockingMode parse(String value, String defaultValue) {
+      SnapshotLockingMode mode = parse(value);
+      if (mode == null && defaultValue != null) {
+        mode = parse(defaultValue);
+      }
+      return mode;
+    }
+  }
+
+  /**
+   * The set of predefined SecureConnectionMode options or aliases.
+   */
+  public enum SecureConnectionMode implements EnumeratedValue {
+    /**
+     * Establish an unencrypted connection.
+     */
+    DISABLED("disabled"),
+
+    /**
+     * Establish a secure (encrypted) connection if the server supports secure connections.
+     * Fall back to an unencrypted connection otherwise.
+     */
+    PREFERRED("preferred"),
+    /**
+     * Establish a secure connection if the server supports secure connections.
+     * The connection attempt fails if a secure connection cannot be established.
+     */
+    REQUIRED("required"),
+    /**
+     * Like REQUIRED, but additionally verify the server TLS certificate against the configured Certificate Authority
+     * (CA) certificates. The connection attempt fails if no valid matching CA certificates are found.
+     */
+    VERIFY_CA("verify_ca"),
+    /**
+     * Like VERIFY_CA, but additionally verify that the server certificate matches the host to which the connection is
+     * attempted.
+     */
+    VERIFY_IDENTITY("verify_identity");
+
+    private final String value;
+
+    SecureConnectionMode(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @return the matching option, or null if no match is found
+     */
+    public static SecureConnectionMode parse(String value) {
+      if (value == null) {
+        return null;
+      }
+      value = value.trim();
+      for (SecureConnectionMode option : SecureConnectionMode.values()) {
+        if (option.getValue().equalsIgnoreCase(value)) {
+          return option;
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @param defaultValue the default value; may be null
+     * @return the matching option, or null if no match is found and the non-null default is invalid
+     */
+    public static SecureConnectionMode parse(String value, String defaultValue) {
+      SecureConnectionMode mode = parse(value);
+      if (mode == null && defaultValue != null) {
+        mode = parse(defaultValue);
+      }
+      return mode;
+    }
+  }
+
+  /**
+   * The set of predefined Gtid New Channel Position options.
+   */
+  public enum GtidNewChannelPosition implements EnumeratedValue {
+
+    /**
+     * This mode will start reading new gtid channel from mysql servers last_executed position
+     */
+    LATEST("latest"),
+
+    /**
+     * This mode will start reading new gtid channel from earliest available position in server.
+     * This is needed when during active-passive failover the new gtid channel becomes active and receiving writes.
+     * #DBZ-923
+     */
+    EARLIEST("earliest");
+
+    private final String value;
+
+    GtidNewChannelPosition(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @return the matching option, or null if no match is found
+     */
+    public static GtidNewChannelPosition parse(String value) {
+      if (value == null) {
+        return null;
+      }
+      value = value.trim();
+      for (GtidNewChannelPosition option : GtidNewChannelPosition.values()) {
+        if (option.getValue().equalsIgnoreCase(value)) {
+          return option;
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @param defaultValue the default value; may be null
+     * @return the matching option, or null if no match is found and the non-null default is invalid
+     */
+    public static GtidNewChannelPosition parse(String value, String defaultValue) {
+      GtidNewChannelPosition mode = parse(value);
+      if (mode == null && defaultValue != null) {
+        mode = parse(defaultValue);
+      }
+      return mode;
+    }
+  }
+
+  /**
+   * The set of predefined modes for dealing with failures during binlog event processing.
+   */
+  public enum EventProcessingFailureHandlingMode implements EnumeratedValue {
+
+    /**
+     * Problematic events will be skipped.
+     */
+    IGNORE("ignore"),
+
+    /**
+     * Problematic event and their binlog position will be logged and the events will be skipped.
+     */
+    WARN("warn"),
+
+    /**
+     * An exception indicating the problematic events and their binlog position is raised, causing the connector to be
+     * stopped.
+     */
+    FAIL("fail");
+
+    private final String value;
+
+    EventProcessingFailureHandlingMode(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @return the matching option, or null if no match is found
+     */
+    public static EventProcessingFailureHandlingMode parse(String value) {
+      if (value == null) {
+        return null;
+      }
+
+      value = value.trim();
+
+      for (EventProcessingFailureHandlingMode option : EventProcessingFailureHandlingMode.values()) {
+        if (option.getValue().equalsIgnoreCase(value)) {
+          return option;
+        }
+      }
+
+      return null;
+    }
+  }
+
+  /**
+   * Class for DdlParsingMode
+   */
+  public enum DdlParsingMode implements EnumeratedValue {
+
+    LEGACY("legacy") {
+      @Override
+      public DdlParser getNewParserInstance(JdbcValueConverters valueConverters, TableFilter tableFilter) {
+        return new MySqlDdlParser(false, (MySqlValueConverters) valueConverters);
+      }
+    },
+    ANTLR("antlr") {
+      @Override
+      public DdlParser getNewParserInstance(JdbcValueConverters valueConverters, TableFilter tableFilter) {
+        return new MySqlAntlrDdlParser((MySqlValueConverters) valueConverters, tableFilter);
+      }
+    };
+
+    private final String value;
+
+    DdlParsingMode(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    public abstract DdlParser getNewParserInstance(JdbcValueConverters valueConverters, TableFilter tableFilter);
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @return the matching option, or null if no match is found
+     */
+    public static DdlParsingMode parse(String value) {
+      if (value == null) {
+        return null;
+      }
+      value = value.trim();
+      for (DdlParsingMode option : DdlParsingMode.values()) {
+        if (option.getValue().equalsIgnoreCase(value)) {
+          return option;
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @param defaultValue the default value; may be null
+     * @return the matching option, or null if no match is found and the non-null default is invalid
+     */
+    public static DdlParsingMode parse(String value, String defaultValue) {
+      DdlParsingMode mode = parse(value);
+      if (mode == null && defaultValue != null) {
+        mode = parse(defaultValue);
+      }
+      return mode;
+    }
+  }
+
+  /**
+   * {@link Integer#MIN_VALUE Minimum value} used for fetch size hint.
+   * See <a href="https://issues.jboss.org/browse/DBZ-94">DBZ-94</a> for details.
+   */
+  protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = Integer.MIN_VALUE;
+
+  private static final String DATABASE_WHITELIST_NAME = "database.whitelist";
+  private static final String DATABASE_BLACKLIST_NAME = "database.blacklist";
+  private static final String TABLE_WHITELIST_NAME = "table.whitelist";
+  private static final String TABLE_BLACKLIST_NAME = "table.blacklist";
+  private static final String TABLE_IGNORE_BUILTIN_NAME = "table.ignore.builtin";
+
+  /**
+   * Default size of the binlog buffer used for examining transactions and
+   * deciding whether to propagate them or not. A size of 0 disables the buffer,
+   * all events will be passed on directly as they are passed by the binlog
+   * client.
+   */
+  private static final int DEFAULT_BINLOG_BUFFER_SIZE = 0;
+
+  public static final Field HOSTNAME = Field.create("database.hostname")
+    .withDisplayName("Hostname")
+    .withType(Type.STRING)
+    .withWidth(Width.MEDIUM)
+    .withImportance(Importance.HIGH)
+    .withValidation(Field::isRequired)
+    .withDescription("Resolvable hostname or IP address of the MySQL database server.");
+
+  public static final Field PORT = Field.create("database.port")
+    .withDisplayName("Port")
+    .withType(Type.INT)
+    .withWidth(Width.SHORT)
+    .withDefault(3306)
+    .withImportance(Importance.HIGH)
+    .withValidation(Field::isInteger)
+    .withDescription("Port of the MySQL database server.");
+
+  public static final Field USER = Field.create("database.user")
+    .withDisplayName("User")
+    .withType(Type.STRING)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.HIGH)
+    .withValidation(Field::isRequired)
+    .withDescription("Name of the MySQL database user to be used when connecting to the database.");
+
+  public static final Field PASSWORD = Field.create("database.password")
+    .withDisplayName("Password")
+    .withType(Type.PASSWORD)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.HIGH)
+    .withDescription("Password of the MySQL database user to be used when connecting to the database.");
+
+  public static final Field ON_CONNECT_STATEMENTS = Field.create("database.initial.statements")
+    .withDisplayName("Initial statements")
+    .withType(Type.STRING)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.LOW)
+    .withDescription("A semicolon separated list of SQL statements to be executed when a JDBC connection " +
+                       "(not binlog reading connection) to the database is established. "
+                       + "Note that the connector may establish JDBC connections at its own discretion, so this " +
+                       "should typically be used for configuration of session parameters only,"
+                       + "but not for executing DML statements. Use doubled semicolon (';;') to use a semicolon " +
+                       "as a character and not as a delimiter.");
+
+  public static final Field SERVER_ID = Field.create("database.server.id")
+    .withDisplayName("Cluster ID")
+    .withType(Type.LONG)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.HIGH)
+    .withDefault(MySqlConnectorConfig::randomServerId)
+    .withValidation(Field::isRequired, Field::isPositiveLong)
+    .withDescription("A numeric ID of this database client, which must be unique across all "
+                       + "currently-running database processes in the cluster. This connector joins the "
+                       + "MySQL database cluster as another server (with this unique ID) so it can read "
+                       + "the binlog. By default, a random number is generated between 5400 and 6400.");
+
+  public static final Field SERVER_ID_OFFSET = Field.create("database.server.id.offset")
+    .withDisplayName("Cluster ID offset")
+    .withType(Type.LONG)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.HIGH)
+    .withDefault(10000L)
+    .withDescription("Only relevant if parallel snapshotting is configured. During "
+                       + "parallel snapshotting, multiple (4) connections open to the database "
+                       + "client, and they each need their own unique connection ID. This offset is "
+                       + "used to generate those IDs from the base configured cluster ID.");
+
+  public static final Field SSL_MODE = Field.create("database.ssl.mode")
+    .withDisplayName("SSL mode")
+    .withEnum(SecureConnectionMode.class, SecureConnectionMode.DISABLED)
+    .withWidth(Width.MEDIUM)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Whether to use an encrypted connection to MySQL. Options include"
+                       + "'disabled' (the default) to use an unencrypted connection; "
+                       + "'preferred' to establish a secure (encrypted) connection if the server supports " +
+                       "secure connections, "
+                       + "but fall back to an unencrypted connection otherwise; "
+                       + "'required' to use a secure (encrypted) connection, and fail if one cannot be established; "
+                       + "'verify_ca' like 'required' but additionally verify the server TLS certificate against the " +
+                       "configured Certificate Authority "
+                       + "(CA) certificates, or fail if no valid matching CA certificates are found; or"
+                       + "'verify_identity' like 'verify_ca' but additionally verify that the server certificate " +
+                       "matches the host to which the connection is attempted.");
+
+  public static final Field SSL_KEYSTORE = Field.create("database.ssl.keystore")
+    .withDisplayName("SSL Keystore")
+    .withType(Type.STRING)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Location of the Java keystore file containing an application process's own " +
+                       "certificate and private key.");
+
+  public static final Field SSL_KEYSTORE_PASSWORD = Field.create("database.ssl.keystore.password")
+    .withDisplayName("SSL Keystore Password")
+    .withType(Type.PASSWORD)
+    .withWidth(Width.MEDIUM)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Password to access the private key from the keystore file specified by 'ssl.keystore' " +
+                       "configuration property or the 'javax.net.ssl.keyStore' system or JVM property. "
+                       + "This password is used to unlock the keystore file (store password), and to decrypt the " +
+                       "private key stored in the keystore (key password).");
+
+  public static final Field SSL_TRUSTSTORE = Field.create("database.ssl.truststore")
+    .withDisplayName("SSL Truststore")
+    .withType(Type.STRING)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Location of the Java truststore file containing the collection of CA certificates trusted by " +
+                       "this application process (trust store).");
+
+  public static final Field SSL_TRUSTSTORE_PASSWORD = Field.create("database.ssl.truststore.password")
+    .withDisplayName("SSL Truststore Password")
+    .withType(Type.PASSWORD)
+    .withWidth(Width.MEDIUM)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Password to unlock the keystore file (store password) specified by 'ssl.trustore' " +
+                       "configuration property or the 'javax.net.ssl.trustStore' system or JVM property.");
+
+  public static final Field TABLES_IGNORE_BUILTIN = Field.create(TABLE_IGNORE_BUILTIN_NAME)
+    .withDisplayName("Ignore system databases")
+    .withType(Type.BOOLEAN)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.LOW)
+    .withDefault(true)
+    .withValidation(Field::isBoolean)
+    .withDependents(DATABASE_WHITELIST_NAME)
+    .withDescription("Flag specifying whether built-in tables should be ignored.");
+
+  // This is the only changed from the original file.
+  // We basically just delete the usage of 'com.mysql.cj.jdbc.Driver' class
+  public static final Field JDBC_DRIVER = Field.create("database.jdbc.driver")
+    .withDisplayName("Jdbc Driver Class Name")
+    .withType(Type.CLASS)
+    .withWidth(Width.MEDIUM)
+    .withImportance(Importance.LOW)
+    .withValidation(Field::isClassName)
+    .withDescription("JDBC Driver class name used to connect to the MySQL database server.");
+
+  /**
+   * A comma-separated list of regular expressions that match database names to be monitored.
+   * May not be used with {@link #DATABASE_BLACKLIST}.
+   */
+  public static final Field DATABASE_WHITELIST = Field.create(DATABASE_WHITELIST_NAME)
+    .withDisplayName("Databases")
+    .withType(Type.LIST)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.HIGH)
+    .withDependents(TABLE_WHITELIST_NAME)
+    .withDescription("The databases for which changes are to be captured");
+
+  /**
+   * A comma-separated list of regular expressions that match database names to be excluded from monitoring.
+   * May not be used with {@link #DATABASE_WHITELIST}.
+   */
+  public static final Field DATABASE_BLACKLIST = Field.create(DATABASE_BLACKLIST_NAME)
+    .withDisplayName("Exclude Databases")
+    .withType(Type.STRING)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.MEDIUM)
+    .withValidation(MySqlConnectorConfig::validateDatabaseBlacklist)
+    .withInvisibleRecommender()
+    .withDescription("");
+
+  /**
+   * A comma-separated list of regular expressions that match the fully-qualified names of tables to be monitored.
+   * Fully-qualified names for tables are of the form {@code <databaseName>.<tableName>} or
+   * {@code <databaseName>.<schemaName>.<tableName>}. May not be used with {@link #TABLE_BLACKLIST}, and superseded by
+   * database inclusions/exclusions.
+   */
+  public static final Field TABLE_WHITELIST = Field.create(TABLE_WHITELIST_NAME)
+    .withDisplayName("Tables")
+    .withType(Type.LIST)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.HIGH)
+    .withValidation(Field::isListOfRegex)
+    .withDescription("The tables for which changes are to be captured");
+
+  /**
+   * A comma-separated list of regular expressions that match the fully-qualified names of tables to be excluded from
+   * monitoring. Fully-qualified names for tables are of the form {@code <databaseName>.<tableName>} or
+   * {@code <databaseName>.<schemaName>.<tableName>}. May not be used with {@link #TABLE_WHITELIST}.
+   */
+  public static final Field TABLE_BLACKLIST = Field.create(TABLE_BLACKLIST_NAME)
+    .withDisplayName("Exclude Tables")
+    .withType(Type.STRING)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.MEDIUM)
+    .withValidation(Field::isListOfRegex, MySqlConnectorConfig::validateTableBlacklist)
+    .withInvisibleRecommender();
+
+  /**
+   * A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog
+   * position in the MySQL server. Only the GTID ranges that have sources matching one of these include patterns will
+   * be used.
+   * May not be used with {@link #GTID_SOURCE_EXCLUDES}.
+   */
+  public static final Field GTID_SOURCE_INCLUDES = Field.create("gtid.source.includes")
+    .withDisplayName("Include GTID sources")
+    .withType(Type.LIST)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.HIGH)
+    .withDependents(TABLE_WHITELIST_NAME)
+    .withDescription("The source UUIDs used to include GTID ranges when determine the starting position in the MySQL " +
+                       "server's binlog.");
+
+  /**
+   * A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog
+   * position in the MySQL server. Only the GTID ranges that have sources matching none of these exclude patterns will
+   * be used.
+   * May not be used with {@link #GTID_SOURCE_INCLUDES}.
+   */
+  public static final Field GTID_SOURCE_EXCLUDES = Field.create("gtid.source.excludes")
+    .withDisplayName("Exclude GTID sources")
+    .withType(Type.STRING)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.MEDIUM)
+    .withValidation(MySqlConnectorConfig::validateGtidSetExcludes)
+    .withInvisibleRecommender()
+    .withDescription("The source UUIDs used to exclude GTID ranges when determine the starting position in the MySQL " +
+                       "server's binlog.");
+
+  /**
+   * If set to true, we will only produce DML events into Kafka for transactions that were written on MySQL servers
+   * with UUIDs matching the filters defined by the {@link #GTID_SOURCE_INCLUDES} or {@link #GTID_SOURCE_EXCLUDES}
+   * configuration options, if they are specified.
+   *
+   * Defaults to true.
+   *
+   * When true, either {@link #GTID_SOURCE_INCLUDES} or {@link #GTID_SOURCE_EXCLUDES} must be set.
+   */
+  public static final Field GTID_SOURCE_FILTER_DML_EVENTS = Field.create("gtid.source.filter.dml.events")
+    .withDisplayName("Filter DML events")
+    .withType(Type.BOOLEAN)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDefault(true)
+    .withDescription("If set to true, we will only produce DML events into Kafka for transactions that were " +
+                       "written on mysql servers with UUIDs matching the filters defined by the gtid.source.includes " +
+                       "or gtid.source.excludes configuration options, if they are specified.");
+
+  /**
+   * If set to 'latest', connector when encountering new GTID channel after job restart will start reading it from the
+   * latest executed position (default). When set to 'earliest' the connector will start reading new GTID channels
+   * from the first available position. This is useful when in active-passive mysql setup during failover new GTID
+   * channel starts receiving writes, see DBZ-923.
+   *
+   * Defaults to latest.
+   */
+  public static final Field GTID_NEW_CHANNEL_POSITION = Field.create("gtid.new.channel.position")
+    .withDisplayName("GTID start position")
+    .withEnum(GtidNewChannelPosition.class, GtidNewChannelPosition.LATEST)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("If set to 'latest', when connector sees new GTID, it will start consuming gtid channel " +
+                       "from the server latest executed gtid position. If 'earliest' connector starts reading " +
+                       "channel from first available (not purged) gtid position on the server.");
+
+  public static final Field CONNECTION_TIMEOUT_MS = Field.create("connect.timeout.ms")
+    .withDisplayName("Connection Timeout (ms)")
+    .withType(Type.INT)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Maximum time in milliseconds to wait after trying to connect to the database before timing out.")
+    .withDefault(30 * 1000)
+    .withValidation(Field::isPositiveInteger);
+
+  public static final Field KEEP_ALIVE = Field.create("connect.keep.alive")
+    .withDisplayName("Keep connection alive (true/false)")
+    .withType(Type.BOOLEAN)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.LOW)
+    .withDescription("Whether a separate thread should be used to ensure the connection is kept alive.")
+    .withDefault(true)
+    .withValidation(Field::isBoolean);
+
+  public static final Field KEEP_ALIVE_INTERVAL_MS = Field.create("connect.keep.alive.interval.ms")
+    .withDisplayName("Keep alive interval (ms)")
+    .withType(Type.LONG)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.LOW)
+    .withDescription("Interval in milliseconds to wait for connection checking if keep alive thread is used.")
+    .withDefault(Duration.ofMinutes(1).toMillis())
+    .withValidation(Field::isPositiveInteger);
+
+  public static final Field ROW_COUNT_FOR_STREAMING_RESULT_SETS = Field.create("min.row.count.to.stream.results")
+    .withDisplayName("Stream result set of size")
+    .withType(Type.LONG)
+    .withWidth(Width.MEDIUM)
+    .withImportance(Importance.LOW)
+    .withDescription("The number of rows a table must contain to stream results rather than pull "
+                       + "all into memory during snapshots. Defaults to 1,000. Use 0 to stream all results "
+                       + "and completely avoid checking the size of each table.")
+    .withDefault(1_000)
+    .withValidation(Field::isNonNegativeLong);
+
+  public static final Field BUFFER_SIZE_FOR_BINLOG_READER = Field.create("binlog.buffer.size")
+    .withDisplayName("Binlog reader buffer size")
+    .withType(Type.INT)
+    .withWidth(Width.MEDIUM)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("The size of a look-ahead buffer used by the  binlog reader to decide whether "
+                       + "the transaction in progress is going to be committed or rolled back. "
+                       + "Use 0 to disable look-ahead buffering. "
+                       + "Defaults to " + DEFAULT_BINLOG_BUFFER_SIZE + " (i.e. buffering is disabled).")
+    .withDefault(DEFAULT_BINLOG_BUFFER_SIZE)
+    .withValidation(Field::isNonNegativeInteger);
+
+  /**
+   * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user
+   * interface, and in these situations using Kafka is the only way to go.
+   */
+  public static final Field DATABASE_HISTORY = Field.create("database.history")
+    .withDisplayName("Database history class")
+    .withType(Type.CLASS)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.LOW)
+    .withInvisibleRecommender()
+    .withDescription("The name of the DatabaseHistory class that should be used to store and recover database " +
+                       "schema changes. The configuration properties for the history are prefixed with the '" +
+                       DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING + "' string.")
+    .withDefault(KafkaDatabaseHistory.class.getName());
+
+  public static final Field INCLUDE_SCHEMA_CHANGES = Field.create("include.schema.changes")
+    .withDisplayName("Include database schema changes")
+    .withType(Type.BOOLEAN)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Whether the connector should publish changes in the database schema to a Kafka topic with " +
+                       "the same name as the database server ID. Each schema change will be recorded using a " +
+                       "key that contains the database name and whose value includes the DDL statement(s)." +
+                       "The default is 'true'. This is independent of how the connector internally records database " +
+                       "history.")
+    .withDefault(true);
+
+  public static final Field INCLUDE_SQL_QUERY = Field.create("include.query")
+    .withDisplayName("Include original SQL query with in change events")
+    .withType(Type.BOOLEAN)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Whether the connector should include the original SQL query that generated the change event. " +
+                       "Note: This option requires MySQL be configured with the binlog_rows_query_log_events " +
+                       "option set to ON. Query will not be present for events generated from snapshot. " +
+                       "WARNING: Enabling this option may expose tables or fields explicitly blacklisted or masked " +
+                       "by including the original SQL statement in the change event. " +
+                       "For this reason the default value is 'false'.")
+    .withDefault(false);
+
+  public static final Field SNAPSHOT_MODE = Field.create("snapshot.mode")
+    .withDisplayName("Snapshot mode")
+    .withEnum(SnapshotMode.class, SnapshotMode.INITIAL)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.LOW)
+    .withDescription("The criteria for running a snapshot upon startup of the connector. " +
+                       "Options include: 'when_needed' to specify that the connector run a snapshot upon startup " +
+                       "whenever it deems it necessary; 'initial' (the default) to specify the connector can run " +
+                       "a snapshot only when no offsets are available for the logical server name; " +
+                       "'initial_only' same as 'initial' except the connector should stop after completing the " +
+                       "snapshot and before it would normally read the binlog; and 'never' to specify the " +
+                       "connector should never run a snapshot and that upon first startup the connector should " +
+                       "read from the beginning of the binlog. The 'never' mode should be used with care, and " +
+                       "only when the binlog is known to contain all history.");
+
+  /**
+   * @deprecated Replaced with SNAPSHOT_LOCKING_MODE
+   */
+  @Deprecated
+  public static final Field SNAPSHOT_MINIMAL_LOCKING = Field.create("snapshot.minimal.locks")
+    .withDisplayName("Use shortest database locking for snapshots")
+    .withType(Type.BOOLEAN)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.LOW)
+    .withDescription("NOTE: This option has been deprecated in favor of snapshot.locking.mode. \n"
+                       + "Controls how long the connector holds onto the global read lock while it is performing " +
+                       "a snapshot. The default is 'true', which means the connector holds the global read lock " +
+                       "(and thus prevents any updates) for just the initial portion of the snapshot "
+                       + "while the database schemas and other metadata are being read. The remaining work in a " +
+                       "snapshot involves selecting all rows from "
+                       + "each table, and this can be done using the snapshot process' REPEATABLE READ transaction " +
+                       "even when the lock is no longer held and "
+                       + "other operations are updating the database. However, in some cases it may be desirable " +
+                       "to block all writes for the entire duration "
+                       + "of the snapshot; in such cases set this property to 'false'.")
+    .withDefault(true);
+
+  public static final Field SNAPSHOT_LOCKING_MODE = Field.create("snapshot.locking.mode")
+    .withDisplayName("Snapshot locking mode")
+    .withEnum(SnapshotLockingMode.class, SnapshotLockingMode.MINIMAL)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.LOW)
+    .withDescription("Controls how long the connector holds onto the global read lock while it is performing a " +
+                       "snapshot. The default is 'minimal', which means the connector holds the global read lock " +
+                       "(and thus prevents any updates) for just the initial portion of the snapshot " +
+                       "while the database schemas and other metadata are being read. The remaining work in " +
+                       "a snapshot involves selecting all rows from each table, and this can be done using the " +
+                       "snapshot process' REPEATABLE READ transaction even when the lock is no longer held and " +
+                       "other operations are updating the database. However, in some cases it may be desirable " +
+                       "to block all writes for the entire duration of the snapshot; in such cases set this " +
+                       "property to 'extended'. Using a value of 'none' will prevent the connector from acquiring " +
+                       "any table locks during the snapshot process. This mode can only be used in combination with " +
+                       "snapshot.mode values of 'schema_only' or 'schema_only_recovery' and is only safe to use" +
+                       " if no schema changes are happening while the snapshot is taken.")
+    .withValidation(MySqlConnectorConfig::validateSnapshotLockingMode);
+
+  public static final Field SNAPSHOT_NEW_TABLES = Field.create("snapshot.new.tables")
+    .withDisplayName("Snapshot newly added tables")
+    .withEnum(SnapshotNewTables.class, SnapshotNewTables.OFF)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.LOW)
+    .withDescription("BETA FEATURE: On connector restart, the connector will check if there have been any new tables " +
+                       "added to the configuration, and snapshot them. There is presently only two options:" +
+                       "'off': Default behavior. Do not snapshot new tables." +
+                       "'parallel': The snapshot of the new tables will occur in parallel to the continued binlog " +
+                       "reading of the old tables. When the snapshot completes, an independent binlog reader will " +
+                       "begin reading the events for the new tables until it catches up to present time. At this " +
+                       "point, both old and new binlog readers will be momentarily halted and new binlog reader " +
+                       "will start that will read the binlog for all configured tables. The parallel binlog reader " +
+                       "will have a configured server id of 10000 + the primary binlog reader's server id.");
+
+  public static final Field TIME_PRECISION_MODE = Field.create("time.precision.mode")
+    .withDisplayName("Time Precision")
+    .withEnum(TemporalPrecisionMode.class, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Time, date, and timestamps can be represented with different kinds of precisions, including:" +
+                       "'adaptive_time_microseconds' (the default) like 'adaptive' mode, but TIME fields always " +
+                       "use microseconds precision; 'adaptive' (deprecated) bases the precision of time, date, " +
+                       "and timestamp values on the database column's precision; 'connect' always represents " +
+                       "time, date, and timestamp values using Kafka Connect's built-in representations for Time, " +
+                       "Date, and Timestamp, which uses millisecond precision regardless of the database " +
+                       "columns' precision.");
+
+  public static final Field BIGINT_UNSIGNED_HANDLING_MODE = Field.create("bigint.unsigned.handling.mode")
+    .withDisplayName("BIGINT UNSIGNED Handling")
+    .withEnum(BigIntUnsignedHandlingMode.class, BigIntUnsignedHandlingMode.LONG)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Specify how BIGINT UNSIGNED columns should be represented in change events, including:" +
+                       "'precise' uses java.math.BigDecimal to represent values, which are encoded in the " +
+                       "change events using a binary representation and Kafka Connect's " +
+                       "'org.apache.kafka.connect.data.Decimal' type; 'long' (the default) represents values " +
+                       "using Java's 'long', which may not offer the precision but will be far easier to use " +
+                       "in consumers.");
+
+  public static final Field EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE =
+    Field.create("event.deserialization.failure.handling.mode")
+    .withDisplayName("Event deserialization failure handling")
+    .withEnum(EventProcessingFailureHandlingMode.class, EventProcessingFailureHandlingMode.FAIL)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Specify how failures during deserialization of binlog events (i.e. when encountering a " +
+                       "corrupted event) should be handled, including: 'fail' (the default) an exception indicating " +
+                       "the problematic event and its binlog position is raised, causing the connector to be " +
+                       "stopped; 'warn' the problematic event and its binlog position will be logged and the event" +
+                       " will be skipped; 'ignore' the problematic event will be skipped.");
+
+  public static final Field INCONSISTENT_SCHEMA_HANDLING_MODE = Field.create("inconsistent.schema.handling.mode")
+    .withDisplayName("Inconsistent schema failure handling")
+    .withEnum(EventProcessingFailureHandlingMode.class, EventProcessingFailureHandlingMode.FAIL)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("Specify how binlog events that belong to a table missing from internal schema representation " +
+                       "(i.e. internal representation is not consistent with database) should be handled, including:"
+                       + "'fail' (the default) an exception indicating the problematic event and its binlog position " +
+                       "is raised, causing the connector to be stopped; 'warn' the problematic event and its binlog " +
+                       "position will be logged and the event will be skipped; 'ignore' the problematic event " +
+                       "will be skipped.");
+
+  public static final Field SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE =
+    Field.create("snapshot.select.statement.overrides")
+    .withDisplayName("List of tables where the default select statement used during snapshotting should be overridden.")
+    .withType(Type.STRING)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.MEDIUM)
+    .withDescription(" This property contains a comma-separated list of fully-qualified tables (DB_NAME.TABLE_NAME). " +
+                       "Select statements for the individual tables are specified in further configuration " +
+                       "properties, one for each table, identified by the id " +
+                       "'snapshot.select.statement.overrides.[DB_NAME].[TABLE_NAME]'. " +
+                       "The value of those properties is the select statement to use when retrieving data from " +
+                       "the specific table during snapshotting. " +
+                       "A possible use case for large append-only tables is setting a specific point where to " +
+                       "start (resume) snapshotting, in case a previous snapshotting was interrupted.");
+
+  public static final Field DDL_PARSER_MODE = Field.create("ddl.parser.mode")
+    .withDisplayName("DDL parser mode")
+    .withEnum(DdlParsingMode.class, DdlParsingMode.ANTLR)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.MEDIUM)
+    .withDescription("MySQL DDL statements can be parsed in different ways:" +
+                       "'legacy' parsing is creating a TokenStream and comparing token by token with an " +
+                       "expected values." +
+                       "The decisions are made by matched token values." +
+                       "'antlr' (the default) uses generated parser from MySQL grammar using ANTLR v4 tool" +
+                       " which use ALL(*) algorithm for parsing." +
+                       "This parser creates a parsing tree for DDL statement, then walks trough it and apply " +
+                       "changes by node types in parsed tree.");
+
+  /**
+   * Method that generates a Field for specifying that string columns whose names match a set of regular expressions
+   * should have their values truncated to be no longer than the specified number of characters.
+   *
+   * @param length the maximum length of the column's string values written in source records; must be positive
+   * @return the field; never null
+   */
+  public static final Field TRUNCATE_COLUMN(int length) {
+    if (length <= 0) {
+      throw new IllegalArgumentException("The truncation length must be positive");
+    }
+    return Field.create("column.truncate.to." + length + ".chars")
+      .withValidation(Field::isInteger)
+      .withDescription("A comma-separated list of regular expressions matching fully-qualified names of columns" +
+                         " that should be truncated to " + length + " characters.");
+  }
+
+  /**
+   * Method that generates a Field for specifying that string columns whose names match a set of regular expressions
+   * should have their values masked by the specified number of asterisk ('*') characters.
+   *
+   * @param length the number of asterisks that should appear in place of the column's string values written in source
+   *               records; must be positive
+   * @return the field; never null
+   */
+  public static final Field MASK_COLUMN(int length) {
+    if (length <= 0) {
+      throw new IllegalArgumentException("The mask length must be positive");
+    }
+    return Field.create("column.mask.with." + length + ".chars")
+      .withValidation(Field::isInteger)
+      .withDescription("A comma-separated list of regular expressions matching fully-qualified names of columns " +
+                         "that should be masked with " + length + " asterisk ('*') characters.");
+  }
+
+  public static final Field ENABLE_TIME_ADJUSTER = Field.create("enable.time.adjuster")
+    .withDisplayName("Enable Time Adjuster")
+    .withType(Type.BOOLEAN)
+    .withDefault(true)
+    .withWidth(Width.SHORT)
+    .withImportance(Importance.LOW)
+    .withDescription("MySQL allows user to insert year value as either 2-digit or 4-digit. In case of two digit " +
+                       "the value is automatically mapped into 1970 - 2069." +
+                       "false - delegates the implicit conversion to the database" +
+                       "true - (the default) Debezium makes the conversion");
+
+  /**
+   * The set of {@link Field}s defined as part of this configuration.
+   */
+  public static Field.Set ALL_FIELDS = Field.setOf(USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS, SERVER_ID,
+                                                   SERVER_ID_OFFSET,
+                                                   RelationalDatabaseConnectorConfig.SERVER_NAME,
+                                                   CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS,
+                                                   CommonConnectorConfig.MAX_QUEUE_SIZE,
+                                                   CommonConnectorConfig.MAX_BATCH_SIZE,
+                                                   CommonConnectorConfig.POLL_INTERVAL_MS,
+                                                   BUFFER_SIZE_FOR_BINLOG_READER, Heartbeat.HEARTBEAT_INTERVAL,
+                                                   Heartbeat.HEARTBEAT_TOPICS_PREFIX, DATABASE_HISTORY,
+                                                   INCLUDE_SCHEMA_CHANGES, INCLUDE_SQL_QUERY,
+                                                   TABLE_WHITELIST, TABLE_BLACKLIST, TABLES_IGNORE_BUILTIN,
+                                                   DATABASE_WHITELIST, DATABASE_BLACKLIST,
+                                                   COLUMN_BLACKLIST,
+                                                   SNAPSHOT_MODE, SNAPSHOT_NEW_TABLES, SNAPSHOT_MINIMAL_LOCKING,
+                                                   SNAPSHOT_LOCKING_MODE,
+                                                   GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES,
+                                                   GTID_SOURCE_FILTER_DML_EVENTS,
+                                                   GTID_NEW_CHANNEL_POSITION,
+                                                   TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
+                                                   SSL_MODE, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD,
+                                                   SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD, JDBC_DRIVER,
+                                                   BIGINT_UNSIGNED_HANDLING_MODE,
+                                                   EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE,
+                                                   INCONSISTENT_SCHEMA_HANDLING_MODE,
+                                                   CommonConnectorConfig.SNAPSHOT_DELAY_MS,
+                                                   CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
+                                                   DDL_PARSER_MODE,
+                                                   CommonConnectorConfig.TOMBSTONES_ON_DELETE, ENABLE_TIME_ADJUSTER);
+
+  /**
+   * The set of {@link Field}s that are included in the {@link #configDef() configuration definition}. This includes
+   * all fields defined in this class (though some are always invisible since they are not to be exposed to the user
+   * interface) plus several that are specific to the {@link KafkaDatabaseHistory} class, since history is always
+   * stored in Kafka when run via the user interface.
+   */
+  protected static Field.Set EXPOSED_FIELDS = ALL_FIELDS.with(KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
+                                                              KafkaDatabaseHistory.TOPIC,
+                                                              KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
+                                                              KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS,
+                                                              DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS,
+                                                              DatabaseHistory.STORE_ONLY_MONITORED_TABLES_DDL,
+                                                              DatabaseHistory.DDL_FILTER);
+
+  private final SnapshotLockingMode snapshotLockingMode;
+  private final DdlParsingMode ddlParsingMode;
+  private final GtidNewChannelPosition gitIdNewChannelPosition;
+  private final SnapshotNewTables snapshotNewTables;
+
+  public MySqlConnectorConfig(Configuration config) {
+    super(
+      config,
+      config.getString(RelationalDatabaseConnectorConfig.SERVER_NAME),
+      null, // TODO whitelist handling is still done locally here
+      null
+    );
+
+    // If deprecated snapshot.minimal.locking property is explicitly configured
+    if (config.hasKey(MySqlConnectorConfig.SNAPSHOT_MINIMAL_LOCKING.name())) {
+      // Coerce it into its replacement appropriate snapshot.locking.mode value
+      if (config.getBoolean(MySqlConnectorConfig.SNAPSHOT_MINIMAL_LOCKING)) {
+        this.snapshotLockingMode = SnapshotLockingMode.MINIMAL;
+      } else {
+        this.snapshotLockingMode = SnapshotLockingMode.EXTENDED;
+      }
+    } else {
+      // Otherwise use configured snapshot.locking.mode configuration.
+      this.snapshotLockingMode =
+        SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE),
+                                  SNAPSHOT_LOCKING_MODE.defaultValueAsString());
+    }
+
+    String ddlParsingModeStr = config.getString(MySqlConnectorConfig.DDL_PARSER_MODE);
+    this.ddlParsingMode = DdlParsingMode.parse(ddlParsingModeStr,
+                                               MySqlConnectorConfig.DDL_PARSER_MODE.defaultValueAsString());
+
+    String gitIdNewChannelPosition = config.getString(MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION);
+    this.gitIdNewChannelPosition =
+      GtidNewChannelPosition.parse(gitIdNewChannelPosition,
+                                   MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION.defaultValueAsString());
+
+    String snapshotNewTables = config.getString(MySqlConnectorConfig.SNAPSHOT_NEW_TABLES);
+    this.snapshotNewTables = SnapshotNewTables.parse(snapshotNewTables,
+                                                     MySqlConnectorConfig.SNAPSHOT_NEW_TABLES.defaultValueAsString());
+  }
+
+  public SnapshotLockingMode getSnapshotLockingMode() {
+    return this.snapshotLockingMode;
+  }
+
+  public DdlParsingMode getDdlParsingMode() {
+    return ddlParsingMode;
+  }
+
+  public GtidNewChannelPosition gtidNewChannelPosition() {
+    return gitIdNewChannelPosition;
+  }
+
+  public SnapshotNewTables getSnapshotNewTables() {
+    return snapshotNewTables;
+  }
+
+  @Override
+  protected int defaultSnapshotFetchSize(Configuration config) {
+    return DEFAULT_SNAPSHOT_FETCH_SIZE;
+  }
+
+  protected static ConfigDef configDef() {
+    ConfigDef config = new ConfigDef();
+    Field.group(config, "MySQL", HOSTNAME, PORT, USER, PASSWORD, ON_CONNECT_STATEMENTS,
+                RelationalDatabaseConnectorConfig.SERVER_NAME, SERVER_ID, SERVER_ID_OFFSET,
+                SSL_MODE, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD, SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD, JDBC_DRIVER);
+    Field.group(config, "History Storage", KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
+                KafkaDatabaseHistory.TOPIC, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
+                KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, DATABASE_HISTORY,
+                DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, DatabaseHistory.DDL_FILTER,
+                DatabaseHistory.STORE_ONLY_MONITORED_TABLES_DDL);
+    Field.group(config, "Events", INCLUDE_SCHEMA_CHANGES, INCLUDE_SQL_QUERY, TABLES_IGNORE_BUILTIN,
+                DATABASE_WHITELIST, TABLE_WHITELIST, COLUMN_BLACKLIST, TABLE_BLACKLIST, DATABASE_BLACKLIST,
+                GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS, GTID_NEW_CHANNEL_POSITION,
+                BUFFER_SIZE_FOR_BINLOG_READER, Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX,
+                EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE, INCONSISTENT_SCHEMA_HANDLING_MODE,
+                CommonConnectorConfig.TOMBSTONES_ON_DELETE);
+    Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS,
+                CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.MAX_BATCH_SIZE,
+                CommonConnectorConfig.POLL_INTERVAL_MS, SNAPSHOT_MODE, SNAPSHOT_LOCKING_MODE, SNAPSHOT_NEW_TABLES,
+                SNAPSHOT_MINIMAL_LOCKING, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE, BIGINT_UNSIGNED_HANDLING_MODE,
+                SNAPSHOT_DELAY_MS, SNAPSHOT_FETCH_SIZE, DDL_PARSER_MODE, ENABLE_TIME_ADJUSTER);
+    return config;
+  }
+
+  private static int validateDatabaseBlacklist(Configuration config, Field field, ValidationOutput problems) {
+    String whitelist = config.getString(DATABASE_WHITELIST);
+    String blacklist = config.getString(DATABASE_BLACKLIST);
+    if (whitelist != null && blacklist != null) {
+      problems.accept(DATABASE_BLACKLIST, blacklist, "Whitelist is already specified");
+      return 1;
+    }
+    return 0;
+  }
+
+  private static int validateTableBlacklist(Configuration config, Field field, ValidationOutput problems) {
+    String whitelist = config.getString(TABLE_WHITELIST);
+    String blacklist = config.getString(TABLE_BLACKLIST);
+    if (whitelist != null && blacklist != null) {
+      problems.accept(TABLE_BLACKLIST, blacklist, "Whitelist is already specified");
+      return 1;
+    }
+    return 0;
+  }
+
+  private static int validateGtidSetExcludes(Configuration config, Field field, ValidationOutput problems) {
+    String includes = config.getString(GTID_SOURCE_INCLUDES);
+    String excludes = config.getString(GTID_SOURCE_EXCLUDES);
+    if (includes != null && excludes != null) {
+      problems.accept(GTID_SOURCE_EXCLUDES, excludes, "Included GTID source UUIDs are already specified");
+      return 1;
+    }
+    return 0;
+  }
+
+  /**
+   * Validate the new snapshot.locking.mode configuration, which replaces snapshot.minimal.locking.
+   *
+   * If minimal.locking is explicitly defined and locking.mode is NOT explicitly defined:
+   *   - coerce minimal.locking into the new snap.locking.mode property.
+   *
+   * If minimal.locking is NOT explicitly defined and locking.mode IS explicitly defined:
+   *   - use new locking.mode property.
+   *
+   * If BOTH minimal.locking and locking.mode ARE defined:
+   *   - Throw a validation error.
+   */
+  private static int validateSnapshotLockingMode(Configuration config, Field field, ValidationOutput problems) {
+    // Determine which configurations are explicitly defined
+    final boolean isMinimalLockingExplicitlyDefined = config.hasKey(SNAPSHOT_MINIMAL_LOCKING.name());
+    final boolean isSnapshotModeExplicitlyDefined = config.hasKey(SNAPSHOT_LOCKING_MODE.name());
+
+    // If both configuration options are explicitly defined, we'll throw a validation error.
+    if (isMinimalLockingExplicitlyDefined && isSnapshotModeExplicitlyDefined) {
+      // Then display a validation error.
+      problems.accept(SNAPSHOT_MINIMAL_LOCKING,
+                      config.getBoolean(SNAPSHOT_MINIMAL_LOCKING),
+                      "Deprecated configuration " + SNAPSHOT_MINIMAL_LOCKING.name() +
+                        " in conflict. Cannot use both " + SNAPSHOT_MINIMAL_LOCKING.name() + " and " +
+                        SNAPSHOT_LOCKING_MODE.name() + " configuration options.");
+      return 1;
+    }
+
+    // Determine what value to use for SnapshotLockingMode
+    final SnapshotLockingMode lockingModeValue;
+
+    // if minimalLocking is defined
+    if (isMinimalLockingExplicitlyDefined) {
+      // Grab the configured minimal locks configuration option
+      final boolean minimalLocksEnabled = config.getBoolean(MySqlConnectorConfig.SNAPSHOT_MINIMAL_LOCKING);
+
+      // Coerce minimal locking => snapshot mode.
+      if (minimalLocksEnabled) {
+        lockingModeValue = SnapshotLockingMode.MINIMAL;
+      } else {
+        lockingModeValue = SnapshotLockingMode.EXTENDED;
+      }
+    } else {
+      // Otherwise use SnapshotLockingMode
+      // Grab explicitly configured value
+      lockingModeValue = SnapshotLockingMode.parse(config.getString(MySqlConnectorConfig.SNAPSHOT_LOCKING_MODE));
+    }
+
+    // Sanity check, validate the configured value is a valid option.
+    if (lockingModeValue == null) {
+      problems.accept(SNAPSHOT_LOCKING_MODE, lockingModeValue, "Must be a valid snapshot.locking.mode value");
+      return 1;
+    }
+
+    // Everything checks out ok.
+    return 0;
+  }
+
+  private static int randomServerId() {
+    int lowestServerId = 5400;
+    int highestServerId = 6400;
+    return lowestServerId + new Random().nextInt(highestServerId - lowestServerId);
+  }
+}

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -42,8 +42,8 @@ public class MySqlJdbcContext implements AutoCloseable {
     "SHOW VARIABLES WHERE Variable_name IN ('character_set_server','collation_server')";
   private static final String SQL_SHOW_SESSION_VARIABLE_SSL_VERSION = "SHOW SESSION STATUS LIKE 'Ssl_version'";
 
-  // This is a change compared with the original file, we intentionally make the 'connectionFactor' a public static
-  // variable, so that we can set the value in CDAP MySql event reader side.
+  // This is a change from the original file, we intentionally make the 'connectionFactor' a public static
+  // variable, so that we can set the value in CDAP side.
   public static ConnectionFactory connectionFactory;
 
   protected final Logger logger = LoggerFactory.getLogger(getClass());

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -42,8 +42,10 @@ public class MySqlJdbcContext implements AutoCloseable {
     "SHOW VARIABLES WHERE Variable_name IN ('character_set_server','collation_server')";
   private static final String SQL_SHOW_SESSION_VARIABLE_SSL_VERSION = "SHOW SESSION STATUS LIKE 'Ssl_version'";
 
-  // This is a change from the original file, we intentionally make the 'connectionFactor' a public static
-  // variable, so that we can set the value in CDAP side.
+  /**
+   * ===================== This is a diff from the original file ===========================
+   * We intentionally make the 'connectionFactor' a public static variable, so that we can set the value in CDAP side.
+   */
   public static ConnectionFactory connectionFactory;
 
   protected final Logger logger = LoggerFactory.getLogger(getClass());

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.Configuration.Builder;
+import io.debezium.config.Field;
+import io.debezium.connector.mysql.MySqlConnectorConfig.EventProcessingFailureHandlingMode;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.jdbc.JdbcConnection.ConnectionFactory;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.util.Strings;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A context for a JDBC connection to MySQL.
+ */
+public class MySqlJdbcContext implements AutoCloseable {
+
+  public static final String MYSQL_CONNECTION_URL =
+    "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}&" +
+      "useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=CONVERT_TO_NULL";
+  protected static final String JDBC_PROPERTY_LEGACY_DATETIME = "useLegacyDatetimeCode";
+
+  private static final String SQL_SHOW_SYSTEM_VARIABLES = "SHOW VARIABLES";
+  private static final String SQL_SHOW_SYSTEM_VARIABLES_CHARACTER_SET =
+    "SHOW VARIABLES WHERE Variable_name IN ('character_set_server','collation_server')";
+  private static final String SQL_SHOW_SESSION_VARIABLE_SSL_VERSION = "SHOW SESSION STATUS LIKE 'Ssl_version'";
+
+  // This is a change compared with the original file, we intentionally make the 'connectionFactor' a public static
+  // variable, so that we can set the value in CDAP MySql event reader side.
+  public static ConnectionFactory connectionFactory;
+
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
+  protected final Configuration config;
+  protected final JdbcConnection jdbc;
+  private final Map<String, String> originalSystemProperties = new HashMap<>();
+
+  public MySqlJdbcContext(Configuration config) {
+    this.config = config; // must be set before most methods are used
+
+    // Set up the JDBC connection without actually connecting, with extra MySQL-specific properties
+    // to give us better JDBC database metadata behavior, including using UTF-8 for the client-side character encoding
+    // per https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-charsets.html
+    boolean useSSL = sslModeEnabled();
+    Configuration jdbcConfig = config
+      .filter(x -> !(x.startsWith(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING) ||
+        x.equals(MySqlConnectorConfig.DATABASE_HISTORY.name())))
+      .subset("database.", true);
+
+    Builder jdbcConfigBuilder = jdbcConfig
+      .edit()
+      .with("useSSL", Boolean.toString(useSSL));
+
+    final String legacyDateTime = jdbcConfig.getString(JDBC_PROPERTY_LEGACY_DATETIME);
+    if (legacyDateTime == null) {
+      jdbcConfigBuilder.with(JDBC_PROPERTY_LEGACY_DATETIME, "false");
+    } else if ("true".equals(legacyDateTime)) {
+      logger.warn("'{}' is set to 'true'. This setting is not recommended and can result in timezone issues.",
+                  JDBC_PROPERTY_LEGACY_DATETIME);
+    }
+
+    jdbcConfig = jdbcConfigBuilder.build();
+    this.jdbc = new JdbcConnection(jdbcConfig, connectionFactory);
+  }
+
+  public Configuration config() {
+    return config;
+  }
+
+  public JdbcConnection jdbc() {
+    return jdbc;
+  }
+
+  public Logger logger() {
+    return logger;
+  }
+
+  public String username() {
+    return config.getString(MySqlConnectorConfig.USER);
+  }
+
+  public String password() {
+    return config.getString(MySqlConnectorConfig.PASSWORD);
+  }
+
+  public String hostname() {
+    return config.getString(MySqlConnectorConfig.HOSTNAME);
+  }
+
+  public int port() {
+    return config.getInteger(MySqlConnectorConfig.PORT);
+  }
+
+  public SecureConnectionMode sslMode() {
+    String mode = config.getString(MySqlConnectorConfig.SSL_MODE);
+    return SecureConnectionMode.parse(mode);
+  }
+
+  public boolean sslModeEnabled() {
+    return sslMode() != SecureConnectionMode.DISABLED;
+  }
+
+  public EventProcessingFailureHandlingMode eventDeserializationFailureHandlingMode() {
+    String mode = config.getString(MySqlConnectorConfig.EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE);
+    return EventProcessingFailureHandlingMode.parse(mode);
+  }
+
+  public EventProcessingFailureHandlingMode inconsistentSchemaHandlingMode() {
+    String mode = config.getString(MySqlConnectorConfig.INCONSISTENT_SCHEMA_HANDLING_MODE);
+    return EventProcessingFailureHandlingMode.parse(mode);
+  }
+
+  public void start() {
+    if (sslModeEnabled()) {
+      originalSystemProperties.clear();
+      // Set the System properties for SSL for the MySQL driver ...
+      setSystemProperty("javax.net.ssl.keyStore", MySqlConnectorConfig.SSL_KEYSTORE, true);
+      setSystemProperty("javax.net.ssl.keyStorePassword", MySqlConnectorConfig.SSL_KEYSTORE_PASSWORD, false);
+      setSystemProperty("javax.net.ssl.trustStore", MySqlConnectorConfig.SSL_TRUSTSTORE, true);
+      setSystemProperty("javax.net.ssl.trustStorePassword", MySqlConnectorConfig.SSL_TRUSTSTORE_PASSWORD, false);
+    }
+  }
+
+  public void shutdown() {
+    try {
+      jdbc.close();
+    } catch (SQLException e) {
+      logger.error("Unexpected error shutting down the database connection", e);
+    } finally {
+      // Reset the system properties to their original value ...
+      originalSystemProperties.forEach((name, value) -> {
+        if (value != null) {
+          System.setProperty(name, value);
+        } else {
+          System.clearProperty(name);
+        }
+      });
+    }
+  }
+
+  @Override
+  public void close() {
+    shutdown();
+  }
+
+  /**
+   * Determine whether the MySQL server has GTIDs enabled.
+   *
+   * @return {@code false} if the server's {@code gtid_mode} is set and is {@code OFF}, or {@code true} otherwise
+   */
+  public boolean isGtidModeEnabled() {
+    AtomicReference<String> mode = new AtomicReference<String>("off");
+    try {
+      jdbc().query("SHOW GLOBAL VARIABLES LIKE 'GTID_MODE'", rs -> {
+        if (rs.next()) {
+          mode.set(rs.getString(2));
+        }
+      });
+    } catch (SQLException e) {
+      throw new ConnectException("Unexpected error while connecting to MySQL and looking at GTID mode: ", e);
+    }
+
+    return !"OFF".equalsIgnoreCase(mode.get());
+  }
+
+  /**
+   * Determine the available GTID set for MySQL.
+   *
+   * @return the string representation of MySQL's GTID sets; never null but an empty string if the server does not use
+   * GTIDs
+   */
+  public String knownGtidSet() {
+    AtomicReference<String> gtidSetStr = new AtomicReference<String>();
+    try {
+      jdbc.query("SHOW MASTER STATUS", rs -> {
+        if (rs.next() && rs.getMetaData().getColumnCount() > 4) {
+          gtidSetStr.set(rs.getString(5)); // GTID set, may be null, blank, or contain a GTID set
+        }
+      });
+    } catch (SQLException e) {
+      throw new ConnectException("Unexpected error while connecting to MySQL and looking at GTID mode: ", e);
+    }
+
+    String result = gtidSetStr.get();
+    return result != null ? result : "";
+  }
+
+  /**
+   * Get the purged GTID values from MySQL (gtid_purged value)
+   *
+   * @return A GTID set; may be empty if not using GTIDs or none have been purged yet
+   */
+  public GtidSet purgedGtidSet() {
+    AtomicReference<String> gtidSetStr = new AtomicReference<String>();
+    try {
+      jdbc.query("SELECT @@global.gtid_purged", rs -> {
+        if (rs.next() && rs.getMetaData().getColumnCount() > 0) {
+          gtidSetStr.set(rs.getString(1)); // GTID set, may be null, blank, or contain a GTID set
+        }
+      });
+    } catch (SQLException e) {
+      throw new ConnectException("Unexpected error while connecting to MySQL and looking at gtid_purged variable: ", e);
+    }
+
+    String result = gtidSetStr.get();
+    if (result == null) {
+      result = "";
+    }
+
+    return new GtidSet(result);
+  }
+
+  /**
+   * Determine if the current user has the named privilege. Note that if the user has the "ALL" privilege this method
+   * returns {@code true}.
+   *
+   * @param grantName the name of the MySQL privilege; may not be null
+   * @return {@code true} if the user has the named privilege, or {@code false} otherwise
+   */
+  public boolean userHasPrivileges(String grantName) {
+    AtomicBoolean result = new AtomicBoolean(false);
+    try {
+      jdbc.query("SHOW GRANTS FOR CURRENT_USER", rs -> {
+        while (rs.next()) {
+          String grants = rs.getString(1);
+          logger.debug(grants);
+          if (grants == null) {
+            return;
+          }
+          grants = grants.toUpperCase();
+          if (grants.contains("ALL") || grants.contains(grantName.toUpperCase())) {
+            result.set(true);
+          }
+        }
+      });
+    } catch (SQLException e) {
+      throw new ConnectException("Unexpected error while connecting to MySQL and looking " +
+                                   "at privileges for current user: ", e);
+    }
+    return result.get();
+  }
+
+  protected String connectionString() {
+    return jdbc.connectionString(MYSQL_CONNECTION_URL);
+  }
+
+  /**
+   * Read the MySQL charset-related system variables.
+   *
+   * @return the system variables that are related to server character sets; never null
+   */
+  protected Map<String, String> readMySqlCharsetSystemVariables() {
+    // Read the system variables from the MySQL instance and get the current database name ...
+    logger.debug("Reading MySQL charset-related system variables before parsing DDL history.");
+    return querySystemVariables(SQL_SHOW_SYSTEM_VARIABLES_CHARACTER_SET);
+  }
+
+  /**
+   * Read the MySQL system variables.
+   *
+   * @return the system variables that are related to server character sets; never null
+   */
+  protected Map<String, String> readMySqlSystemVariables() {
+    // Read the system variables from the MySQL instance and get the current database name ...
+    logger.debug("Reading MySQL system variables");
+    return querySystemVariables(SQL_SHOW_SYSTEM_VARIABLES);
+  }
+
+  private Map<String, String> querySystemVariables(String statement) {
+    Map<String, String> variables = new HashMap<>();
+    try {
+      jdbc.connect().query(statement, rs -> {
+        while (rs.next()) {
+          String varName = rs.getString(1);
+          String value = rs.getString(2);
+          if (varName != null && value != null) {
+            variables.put(varName, value);
+            logger.debug("\t{} = {}",
+                         Strings.pad(varName, 45, ' '),
+                         Strings.pad(value, 45, ' '));
+          }
+        }
+      });
+    } catch (SQLException e) {
+      throw new ConnectException("Error reading MySQL variables: " + e.getMessage(), e);
+    }
+
+    return variables;
+  }
+
+  protected String setStatementFor(Map<String, String> variables) {
+    StringBuilder sb = new StringBuilder("SET ");
+    boolean first = true;
+    List<String> varNames = new ArrayList<>(variables.keySet());
+    Collections.sort(varNames);
+    for (String varName : varNames) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append(", ");
+      }
+      sb.append(varName).append("=");
+      String value = variables.get(varName);
+      if (value == null) {
+        value = "";
+      }
+      if (value.contains(",") || value.contains(";")) {
+        value = "'" + value + "'";
+      }
+      sb.append(value);
+    }
+    return sb.append(";").toString();
+  }
+
+  protected void setSystemProperty(String property, Field field, boolean showValueInError) {
+    String value = config.getString(field);
+    if (value != null) {
+      value = value.trim();
+      String existingValue = System.getProperty(property);
+      if (existingValue == null) {
+        // There was no existing property ...
+        String existing = System.setProperty(property, value);
+        originalSystemProperties.put(property, existing); // the existing value may be null
+      } else {
+        existingValue = existingValue.trim();
+        if (!existingValue.equalsIgnoreCase(value)) {
+          // There was an existing property, and the value is different ...
+          String msg = "System or JVM property '" + property + "' is already defined, but the configuration property '"
+            + field.name()
+            + "' defines a different value";
+          if (showValueInError) {
+            msg = "System or JVM property '" + property + "' is already defined as " + existingValue
+              + ", but the configuration property '" + field.name() + "' defines a different value '" + value + "'";
+          }
+          throw new ConnectException(msg);
+        }
+        // Otherwise, there was an existing property, and the value is exactly the same (so do nothing!)
+      }
+    }
+  }
+
+  /**
+   * Read the Ssl Version session variable.
+   *
+   * @return the session variables that are related to sessions ssl version
+   */
+  protected String getSessionVariableForSslVersion() {
+    final String sslVersion = "Ssl_version";
+    logger.debug("Reading MySQL Session variable for Ssl Version");
+    Map<String, String> sessionVariables =
+      querySystemVariables(SQL_SHOW_SESSION_VARIABLE_SSL_VERSION);
+    if (!sessionVariables.isEmpty() && sessionVariables.containsKey(sslVersion)) {
+      return sessionVariables.get(sslVersion);
+    }
+    return null;
+  }
+}

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -1,0 +1,805 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import com.github.shyiko.mysql.binlog.event.deserialization.AbstractRowsEventDataDeserializer;
+import com.github.shyiko.mysql.binlog.event.deserialization.json.JsonBinary;
+import io.debezium.annotation.Immutable;
+import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
+import io.debezium.data.Json;
+import io.debezium.jdbc.JdbcValueConverters;
+import io.debezium.jdbc.TemporalPrecisionMode;
+import io.debezium.relational.Column;
+import io.debezium.relational.ValueConverter;
+import io.debezium.time.Year;
+import io.debezium.util.Strings;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAdjuster;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * MySQL-specific customization of the conversions from JDBC values obtained from the MySQL binlog client library.
+ * <p>
+ * This class always uses UTC for the default time zone when converting values without timezone information to values
+ * that require timezones. This is because MySQL {@code TIMESTAMP} values are always
+ * <a href="https://dev.mysql.com/doc/refman/5.7/en/datetime.html">stored in UTC</a> (unlike {@code DATETIME} values)
+ * and are replicated in this form. Meanwhile, the MySQL Binlog Client library will
+ * {@link AbstractRowsEventDataDeserializer deserialize} these as {@link java.sql.Timestamp} values that have no
+ * timezone and, therefore, are presumed to be in UTC.
+ * When the column is properly marked with a {@link Types#TIMESTAMP_WITH_TIMEZONE} type, the converters will need
+ * to convert that {@link java.sql.Timestamp} value into an {@link OffsetDateTime} using the default time zone,
+ * which always is UTC.
+ */
+@Immutable
+public class MySqlValueConverters extends JdbcValueConverters {
+
+  /**
+   * Used to parse values of TIME columns. Format: 000:00:00.000000.
+   */
+  private static final Pattern TIME_FIELD_PATTERN = Pattern.compile("(\\-?[0-9]*):([0-9]*):([0-9]*)(\\.([0-9]*))?");
+
+  // This is a change from the original file. It's a hacky way for us to intentionally pass in the jdbc class loader
+  // to load 'com.mysql.cj.CharsetMapping' class so that we can invoke the 'getJavaEncodingForMysqlCharset' static
+  // method.
+  public static ClassLoader jdbcClassLoader;
+
+  /**
+   * A utility method that adjusts <a href="https://dev.mysql.com/doc/refman/5.7/en/two-digit-years.html">ambiguous</a>
+   * 2-digit year values of DATETIME, DATE, and TIMESTAMP types using these MySQL-specific rules:
+   * <ul>
+   * <li>Year values in the range 00-69 are converted to 2000-2069.</li>
+   * <li>Year values in the range 70-99 are converted to 1970-1999.</li>
+   * </ul>
+   *
+   * @param temporal the temporal instance to adjust; may not be null
+   * @return the possibly adjusted temporal instance; never null
+   */
+  protected static Temporal adjustTemporal(Temporal temporal) {
+    if (temporal.isSupported(ChronoField.YEAR)) {
+      int year = temporal.get(ChronoField.YEAR);
+      if (0 <= year && year <= 69) {
+        temporal = temporal.plus(2000, ChronoUnit.YEARS);
+      } else if (70 <= year && year <= 99) {
+        temporal = temporal.plus(1900, ChronoUnit.YEARS);
+      }
+    }
+    return temporal;
+  }
+
+  /**
+   * Create a new instance that always uses UTC for the default time zone when converting values without timezone
+   * information to values that require timezones.
+   * <p>
+   *
+   * @param decimalMode how {@code DECIMAL} and {@code NUMERIC} values should be treated; may be null if
+   *            {@link io.debezium.jdbc.JdbcValueConverters.DecimalMode#PRECISE} is to be used
+   * @param temporalPrecisionMode temporal precision mode based on {@link io.debezium.jdbc.TemporalPrecisionMode}
+   * @param bigIntUnsignedMode how {@code BIGINT UNSIGNED} values should be treated; may be null if
+   *            {@link io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode#PRECISE} is to be used
+   */
+  public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode,
+                              BigIntUnsignedMode bigIntUnsignedMode) {
+    this(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, bigIntUnsignedMode, x-> x);
+  }
+
+  /**
+   * Create a new instance, and specify the time zone offset that should be used only when converting values without
+   * timezone information to values that require timezones. This default offset should not be needed when values are
+   * highly-correlated with the expected SQL/JDBC types.
+   *
+   * @param decimalMode how {@code DECIMAL} and {@code NUMERIC} values should be treated; may be null if
+   *            {@link io.debezium.jdbc.JdbcValueConverters.DecimalMode#PRECISE} is to be used
+   * @param temporalPrecisionMode temporal precision mode based on {@link io.debezium.jdbc.TemporalPrecisionMode}
+   * @param defaultOffset the zone offset that is to be used when converting non-timezone related values to values that
+   *                     do have timezones; may be null if UTC is to be used
+   * @param bigIntUnsignedMode how {@code BIGINT UNSIGNED} values should be treated; may be null if
+   *            {@link io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode#PRECISE} is to be used
+   * @param adjuster a temporal adjuster to make a database specific time modification before conversion
+   */
+  public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode,
+                              ZoneOffset defaultOffset, BigIntUnsignedMode bigIntUnsignedMode,
+                              TemporalAdjuster adjuster) {
+    super(decimalMode, temporalPrecisionMode, defaultOffset, adjuster, bigIntUnsignedMode);
+  }
+
+  /**
+   * Create a new instance that always uses UTC for the default time zone when converting values without timezone
+   * information to values that require timezones.
+   * <p>
+   *
+   * @param decimalMode how {@code DECIMAL} and {@code NUMERIC} values should be treated; may be null if
+   *            {@link io.debezium.jdbc.JdbcValueConverters.DecimalMode#PRECISE} is to be used
+   * @param temporalPrecisionMode temporal precision mode based on {@link io.debezium.jdbc.TemporalPrecisionMode}
+   * @param bigIntUnsignedMode how {@code BIGINT UNSIGNED} values should be treated; may be null if
+   *            {@link io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode#PRECISE} is to be used
+   * @param adjuster a temporal adjuster to make a database specific time modification before conversion
+   */
+  public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode,
+                              BigIntUnsignedMode bigIntUnsignedMode, TemporalAdjuster adjuster) {
+    this(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, bigIntUnsignedMode, adjuster);
+  }
+
+  @Override
+  protected ByteOrder byteOrderOfBitType() {
+    return ByteOrder.BIG_ENDIAN;
+  }
+
+  @Override
+  public SchemaBuilder schemaBuilder(Column column) {
+    // Handle a few MySQL-specific types based upon how they are handled by the MySQL binlog client ...
+    String typeName = column.typeName().toUpperCase();
+    if (matches(typeName, "JSON")) {
+      return Json.builder();
+    }
+    if (matches(typeName, "POINT")) {
+      return io.debezium.data.geometry.Point.builder();
+    }
+    if (matches(typeName, "GEOMETRY")
+      || matches(typeName, "LINESTRING")
+      || matches(typeName, "POLYGON")
+      || matches(typeName, "MULTIPOINT")
+      || matches(typeName, "MULTILINESTRING")
+      || matches(typeName, "MULTIPOLYGON")
+      || isGeometryCollection(typeName)) {
+      return io.debezium.data.geometry.Geometry.builder();
+    }
+    if (matches(typeName, "YEAR")) {
+      return Year.builder();
+    }
+    if (matches(typeName, "ENUM")) {
+      String commaSeperatedOptions = extractEnumAndSetOptionsAsString(column);
+      return io.debezium.data.Enum.builder(commaSeperatedOptions);
+    }
+    if (matches(typeName, "SET")) {
+      String commaSeperatedOptions = extractEnumAndSetOptionsAsString(column);
+      return io.debezium.data.EnumSet.builder(commaSeperatedOptions);
+    }
+    if (matches(typeName, "SMALLINT UNSIGNED") || matches(typeName, "SMALLINT UNSIGNED ZEROFILL")) {
+      // In order to capture unsigned SMALLINT 16-bit data source, INT32 will be required to safely capture all
+      // valid values
+      // Source: https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/data/Schema.Type.html
+      return SchemaBuilder.int32();
+    }
+    if (matches(typeName, "INT UNSIGNED") || matches(typeName, "INT UNSIGNED ZEROFILL")) {
+      // In order to capture unsigned INT 32-bit data source, INT64 will be required to safely capture all valid values
+      // Source: https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/data/Schema.Type.html
+      return SchemaBuilder.int64();
+    }
+    if (matches(typeName, "BIGINT UNSIGNED") || matches(typeName, "BIGINT UNSIGNED ZEROFILL")) {
+      switch (super.bigIntUnsignedMode) {
+        case LONG:
+          return SchemaBuilder.int64();
+        case PRECISE:
+          // In order to capture unsigned INT 64-bit data source, org.apache.kafka.connect.data.Decimal:Byte will be
+          // required to safely capture all valid values with scale of 0
+          // Source: https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/data/Schema.Type.html
+          return Decimal.builder(0);
+      }
+    }
+    // Otherwise, let the base class handle it ...
+    return super.schemaBuilder(column);
+  }
+
+  @Override
+  public ValueConverter converter(Column column, Field fieldDefn) {
+    // Handle a few MySQL-specific types based upon how they are handled by the MySQL binlog client ...
+    String typeName = column.typeName().toUpperCase();
+    if (matches(typeName, "JSON")) {
+      return (data) -> convertJson(column, fieldDefn, data);
+    }
+    if (matches(typeName, "GEOMETRY")
+      || matches(typeName, "LINESTRING")
+      || matches(typeName, "POLYGON")
+      || matches(typeName, "MULTIPOINT")
+      || matches(typeName, "MULTILINESTRING")
+      || matches(typeName, "MULTIPOLYGON")
+      || isGeometryCollection(typeName)) {
+      return (data -> convertGeometry(column, fieldDefn, data));
+    }
+    if (matches(typeName, "POINT")) {
+      // backwards compatibility
+      return (data -> convertPoint(column, fieldDefn, data));
+    }
+    if (matches(typeName, "YEAR")) {
+      return (data) -> convertYearToInt(column, fieldDefn, data);
+    }
+    if (matches(typeName, "ENUM")) {
+      // Build up the character array based upon the column's type ...
+      List<String> options = extractEnumAndSetOptions(column);
+      return (data) -> convertEnumToString(options, column, fieldDefn, data);
+    }
+    if (matches(typeName, "SET")) {
+      // Build up the character array based upon the column's type ...
+      List<String> options = extractEnumAndSetOptions(column);
+      return (data) -> convertSetToString(options, column, fieldDefn, data);
+    }
+    if (matches(typeName, "TINYINT UNSIGNED") || matches(typeName, "TINYINT UNSIGNED ZEROFILL")) {
+      // Convert TINYINT UNSIGNED internally from SIGNED to UNSIGNED based on the boundary settings
+      return (data) -> convertUnsignedTinyint(column, fieldDefn, data);
+    }
+    if (matches(typeName, "SMALLINT UNSIGNED") || matches(typeName, "SMALLINT UNSIGNED ZEROFILL")) {
+      // Convert SMALLINT UNSIGNED internally from SIGNED to UNSIGNED based on the boundary settings
+      return (data) -> convertUnsignedSmallint(column, fieldDefn, data);
+    }
+    if (matches(typeName, "MEDIUMINT UNSIGNED") || matches(typeName, "MEDIUMINT UNSIGNED ZEROFILL")) {
+      // Convert SMALLINT UNSIGNED internally from SIGNED to UNSIGNED based on the boundary settings
+      return (data) -> convertUnsignedMediumint(column, fieldDefn, data);
+    }
+    if (matches(typeName, "INT UNSIGNED") || matches(typeName, "INT UNSIGNED ZEROFILL")) {
+      // Convert INT UNSIGNED internally from SIGNED to UNSIGNED based on the boundary settings
+      return (data) -> convertUnsignedInt(column, fieldDefn, data);
+    }
+    if (matches(typeName, "BIGINT UNSIGNED") || matches(typeName, "BIGINT UNSIGNED ZEROFILL")) {
+      switch (super.bigIntUnsignedMode) {
+        case LONG:
+          return (data) -> convertBigInt(column, fieldDefn, data);
+        case PRECISE:
+          // Convert BIGINT UNSIGNED internally from SIGNED to UNSIGNED based on the boundary settings
+          return (data) -> convertUnsignedBigint(column, fieldDefn, data);
+      }
+    }
+
+    // We have to convert bytes encoded in the column's character set ...
+    switch (column.jdbcType()) {
+      case Types.CHAR: // variable-length
+      case Types.VARCHAR: // variable-length
+      case Types.LONGVARCHAR: // variable-length
+      case Types.CLOB: // variable-length
+      case Types.NCHAR: // fixed-length
+      case Types.NVARCHAR: // fixed-length
+      case Types.LONGNVARCHAR: // fixed-length
+      case Types.NCLOB: // fixed-length
+      case Types.DATALINK:
+      case Types.SQLXML:
+        Charset charset = charsetFor(column);
+        if (charset != null) {
+          logger.debug("Using {} charset by default for column: {}", charset, column);
+          return (data) -> convertString(column, fieldDefn, charset, data);
+        }
+        logger.warn("Using UTF-8 charset by default for column without charset: {}", column);
+        return (data) -> convertString(column, fieldDefn, StandardCharsets.UTF_8, data);
+      case Types.TIME:
+        if (adaptiveTimeMicrosecondsPrecisionMode) {
+          return data -> convertDurationToMicroseconds(column, fieldDefn, data);
+        }
+        break;
+      case Types.TIMESTAMP:
+        return ((ValueConverter) (data -> convertTimestampToLocalDateTime(column, fieldDefn, data)))
+          .and(super.converter(column, fieldDefn));
+      default:
+        break;
+    }
+
+    // Otherwise, let the base class handle it ...
+    return super.converter(column, fieldDefn);
+  }
+
+  /**
+   * Return the {@link Charset} instance with the MySQL-specific character set name used by the given column.
+   *
+   * @param column the column in which the character set is used; never null
+   * @return the Java {@link Charset}, or null if there is no mapping
+   */
+  protected Charset charsetFor(Column column) {
+    String mySqlCharsetName = column.charsetName();
+    if (mySqlCharsetName == null) {
+      logger.warn("Column is missing a character set: {}", column);
+      return null;
+    }
+    String encoding;
+    try {
+      encoding = (String) jdbcClassLoader.loadClass("com.mysql.cj.CharsetMapping")
+        .getMethod("getJavaEncodingForMysqlCharset", String.class)
+        .invoke(null, mySqlCharsetName);
+    } catch (Exception e) {
+      throw new RuntimeException("Error while using class loader to invoke 'getJavaEncodingForMysqlCharset' " +
+                                   "static method", e);
+    }
+
+    if (encoding == null) {
+      logger.warn("Column uses MySQL character set '{}', which has no mapping to a Java character set",
+                  mySqlCharsetName);
+    } else {
+      try {
+        return Charset.forName(encoding);
+      } catch (IllegalCharsetNameException e) {
+        logger.error("Unable to load Java charset '{}' for column with MySQL character set '{}'", encoding,
+                     mySqlCharsetName);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Convert the {@link String} {@code byte[]} value to a string value used in a {@link SourceRecord}.
+   *
+   * @param column the column in which the value appears
+   * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+   * @param data the data; may be null
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertJson(Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, "{}", (r) -> {
+      if (data instanceof byte[]) {
+        // The BinlogReader sees these JSON values as binary encoded, so we use the binlog client library's utility
+        // to parse MySQL's internal binary representation into a JSON string, using the standard formatter.
+
+        if (((byte[]) data).length == 0) {
+          r.deliver(column.isOptional() ? null : "{}");
+        } else {
+          try {
+            r.deliver(JsonBinary.parseAsString((byte[]) data));
+          } catch (IOException e) {
+            throw new ConnectException("Failed to parse and read a JSON value on " + column + ": " + e.getMessage(), e);
+          }
+        }
+      } else if (data instanceof String) {
+        // The SnapshotReader sees JSON values as UTF-8 encoded strings.
+        r.deliver(data);
+      }
+    });
+  }
+
+  /**
+   * Convert the {@link String} or {@code byte[]} value to a string value used in a {@link SourceRecord}.
+   *
+   * @param column the column in which the value appears
+   * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+   * @param columnCharset the Java character set in which column byte[] values are encoded; may not be null
+   * @param data the data; may be null
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertString(Column column, Field fieldDefn, Charset columnCharset, Object data) {
+    return convertValue(column, fieldDefn, data, "", (r) -> {
+      if (data instanceof byte[]) {
+        // Decode the binary representation using the given character encoding ...
+        r.deliver(new String((byte[]) data, columnCharset));
+      } else if (data instanceof String) {
+        r.deliver(data);
+      }
+    });
+  }
+
+  /**
+   * Converts a value object for a MySQL {@code YEAR}, which appear in the binlog as an integer though returns from
+   * the MySQL JDBC driver as either a short or a {@link java.sql.Date}.
+   *
+   * @param column the column definition describing the {@code data} value; never null
+   * @param fieldDefn the field definition; never null
+   * @param data the data object to be converted into a year literal integer value; never null
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  @SuppressWarnings("deprecation")
+  protected Object convertYearToInt(Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, 0, (r) -> {
+      Object mutData = data;
+      if (data instanceof java.time.Year) {
+        // The MySQL binlog always returns a Year object ...
+        r.deliver(adjustTemporal(java.time.Year.of(((java.time.Year) data).getValue())).get(ChronoField.YEAR));
+      } else if (data instanceof java.sql.Date) {
+        // MySQL JDBC driver sometimes returns a Java SQL Date object ...
+        // year from java.sql.Date is defined as number of years since 1900
+        r.deliver(((java.sql.Date) data).getYear() + 1900);
+      } else if (data instanceof String) {
+        mutData = Integer.valueOf((String) data);
+      }
+      if (mutData instanceof Number) {
+        // MySQL JDBC driver sometimes returns a short ...
+        r.deliver(adjustTemporal(java.time.Year.of(((Number) mutData).intValue())).get(ChronoField.YEAR));
+      }
+    });
+  }
+
+  /**
+   * Converts a value object for a MySQL {@code ENUM}, which is represented in the binlog events as an integer value
+   * containing the index of the enum option. The MySQL JDBC driver returns a string containing the option,
+   * so this method calculates the same.
+   *
+   * @param options the characters that appear in the same order as defined in the column; may not be null
+   * @param column the column definition describing the {@code data} value; never null
+   * @param fieldDefn the field definition; never null
+   * @param data the data object to be converted into an {@code ENUM} literal String value
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertEnumToString(List<String> options, Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, "", (r) -> {
+      if (data instanceof String) {
+        // JDBC should return strings ...
+        r.deliver(data);
+      } else if (data instanceof Integer) {
+        if (options != null) {
+          // The binlog will contain an int with the 1-based index of the option in the enum value ...
+          int value = ((Integer) data).intValue();
+          if (value == 0) {
+            // an invalid value was specified, which corresponds to the empty string '' and an index of 0
+            r.deliver("");
+          }
+          int index = value - 1; // 'options' is 0-based
+          if (index < options.size() && index >= 0) {
+            r.deliver(options.get(index));
+          }
+        } else {
+          r.deliver(null);
+        }
+      }
+    });
+  }
+
+  /**
+   * Converts a value object for a MySQL {@code SET}, which is represented in the binlog events contain a long number
+   * in which every bit corresponds to a different option. The MySQL JDBC driver returns a string containing the
+   * comma-separated options, so this method calculates the same.
+   *
+   * @param options the characters that appear in the same order as defined in the column; may not be null
+   * @param column the column definition describing the {@code data} value; never null
+   * @param fieldDefn the field definition; never null
+   * @param data the data object to be converted into an {@code SET} literal String value; never null
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertSetToString(List<String> options, Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, "", (r) -> {
+      if (data instanceof String) {
+        // JDBC should return strings ...
+        r.deliver(data);
+      } else if (data instanceof Long) {
+        // The binlog will contain a long with the indexes of the options in the set value ...
+        long indexes = ((Long) data).longValue();
+        r.deliver(convertSetValue(column, indexes, options));
+      }
+    });
+  }
+
+  /**
+   * Determine if the uppercase form of a column's type exactly matches or begins with the specified prefix.
+   * Note that this logic works when the column's {@link Column#typeName() type} contains the type name followed by
+   * parentheses.
+   *
+   * @param upperCaseTypeName the upper case form of the column's {@link Column#typeName() type name}
+   * @param upperCaseMatch the upper case form of the expected type or prefix of the type; may not be null
+   * @return {@code true} if the type matches the specified type, or {@code false} otherwise
+   */
+  protected boolean matches(String upperCaseTypeName, String upperCaseMatch) {
+    if (upperCaseTypeName == null) {
+      return false;
+    }
+    return upperCaseMatch.equals(upperCaseTypeName) || upperCaseTypeName.startsWith(upperCaseMatch + "(");
+  }
+
+  /**
+   * Determine if the uppercase form of a column's type is geometry collection independent of JDBC driver or server
+   * version.
+   *
+   * @param upperCaseTypeName the upper case form of the column's {@link Column#typeName() type name}
+   * @return {@code true} if the type is geometry collection
+   */
+  protected boolean isGeometryCollection(String upperCaseTypeName) {
+    if (upperCaseTypeName == null) {
+      return false;
+    }
+
+    return upperCaseTypeName.equals("GEOMETRYCOLLECTION") || upperCaseTypeName.equals("GEOMCOLLECTION")
+      || upperCaseTypeName.endsWith(".GEOMCOLLECTION");
+  }
+
+  protected List<String> extractEnumAndSetOptions(Column column) {
+    return MySqlAntlrDdlParser.extractEnumAndSetOptions(column.enumValues());
+  }
+
+  protected String extractEnumAndSetOptionsAsString(Column column) {
+    return Strings.join(",", extractEnumAndSetOptions(column));
+  }
+
+  protected String convertSetValue(Column column, long indexes, List<String> options) {
+    StringBuilder sb = new StringBuilder();
+    int index = 0;
+    boolean first = true;
+    int optionLen = options.size();
+    while (indexes != 0L) {
+      if (indexes % 2L != 0) {
+        if (first) {
+          first = false;
+        } else {
+          sb.append(',');
+        }
+        if (index < optionLen) {
+          sb.append(options.get(index));
+        } else {
+          logger.warn("Found unexpected index '{}' on column {}", index, column);
+        }
+      }
+      ++index;
+      indexes = indexes >>> 1;
+    }
+    return sb.toString();
+
+  }
+
+  /**
+   * Convert the a value representing a POINT {@code byte[]} value to a Point value used in a {@link SourceRecord}.
+   *
+   * @param column the column in which the value appears
+   * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+   * @param data the data; may be null
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertPoint(Column column, Field fieldDefn, Object data) {
+    final MySqlGeometry empty = MySqlGeometry.createEmpty();
+    return convertValue(column, fieldDefn, data,
+                        io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(),
+                                                                       empty.getWkb(),
+                                                                       empty.getSrid()), (r) -> {
+      if (data instanceof byte[]) {
+        // The binlog utility sends a byte array for any Geometry type, we will use our own binaryParse to parse the
+        // byte to WKB, hence to the suitable class
+        MySqlGeometry mySqlGeometry = MySqlGeometry.fromBytes((byte[]) data);
+        if (mySqlGeometry.isPoint()) {
+          r.deliver(io.debezium.data.geometry.Point.createValue(fieldDefn.schema(),
+                                                                mySqlGeometry.getWkb(),
+                                                                mySqlGeometry.getSrid()));
+        } else {
+          throw new ConnectException("Failed to parse and read a value of type POINT on " + column);
+        }
+      }
+    });
+  }
+
+  /**
+   * Convert the a value representing a GEOMETRY {@code byte[]} value to a Geometry value used in a
+   * {@link SourceRecord}.
+   *
+   * @param column the column in which the value appears
+   * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+   * @param data the data; may be null
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertGeometry(Column column, Field fieldDefn, Object data) {
+    final MySqlGeometry empty = MySqlGeometry.createEmpty();
+    return convertValue(column, fieldDefn, data,
+                        io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(),
+                                                                       empty.getWkb(),
+                                                                       empty.getSrid()), (r) -> {
+      if (data instanceof byte[]) {
+        // The binlog utility sends a byte array for any Geometry type, we will use our own binaryParse to parse the
+        // byte to WKB, hence to the suitable class
+        if (data instanceof byte[]) {
+          // The binlog utility sends a byte array for any Geometry type, we will use our own binaryParse to parse the
+          // byte to WKB, hence to the suitable class
+          MySqlGeometry mySqlGeometry = MySqlGeometry.fromBytes((byte[]) data);
+          r.deliver(io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(),
+                                                                   mySqlGeometry.getWkb(),
+                                                                   mySqlGeometry.getSrid()));
+        }
+      }
+    });
+  }
+
+  @Override
+  protected ByteBuffer convertByteArray(Column column, byte[] data) {
+    // DBZ-254 right-pad fixed-length binary column values with 0x00 (zero byte)
+    if (column.jdbcType() == Types.BINARY && data.length < column.length()) {
+      data = Arrays.copyOf(data, column.length());
+    }
+
+    return super.convertByteArray(column, data);
+  }
+
+  /**
+   * Convert the a value representing a Unsigned TINYINT value to the correct Unsigned TINYINT representation.
+   *
+   * @param column the column in which the value appears
+   * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+   * @param data the data; may be null
+   *
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   *
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertUnsignedTinyint(Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, (short) 0, (r) -> {
+      if (data instanceof Short) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedTinyint((short) data));
+      } else if (data instanceof Number) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedTinyint(((Number) data).shortValue()));
+      } else {
+        //We continue with the original converting method (smallint) since we have an unsigned Tinyint
+        r.deliver(convertSmallInt(column, fieldDefn, data));
+      }
+    });
+  }
+
+  /**
+   * Convert the a value representing a Unsigned SMALLINT value to the correct Unsigned SMALLINT representation.
+   *
+   * @param column the column in which the value appears
+   * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+   * @param data the data; may be null
+   *
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   *
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertUnsignedSmallint(Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, 0, (r) -> {
+      if (data instanceof Integer) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedSmallint((int) data));
+      } else if (data instanceof Number) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedSmallint(((Number) data).intValue()));
+      } else {
+        //We continue with the original converting method (integer) since we have an unsigned Smallint
+        r.deliver(convertInteger(column, fieldDefn, data));
+      }
+    });
+  }
+
+  /**
+   * Convert the a value representing a Unsigned MEDIUMINT value to the correct Unsigned SMALLINT representation.
+   *
+   * @param column the column in which the value appears
+   * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+   * @param data the data; may be null
+   *
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   *
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertUnsignedMediumint(Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, 0, (r) -> {
+      if (data instanceof Integer) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedMediumint((int) data));
+      } else if (data instanceof Number) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedMediumint(((Number) data).intValue()));
+      } else {
+        //We continue with the original converting method (integer) since we have an unsigned Medium
+        r.deliver(convertInteger(column, fieldDefn, data));
+      }
+    });
+  }
+
+  /**
+   * Convert the a value representing a Unsigned INT value to the correct Unsigned INT representation.
+   *
+   * @param column the column in which the value appears
+   * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+   * @param data the data; may be null
+   *
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   *
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertUnsignedInt(Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, 0L, (r) -> {
+      if (data instanceof Long) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedInteger((long) data));
+      } else if (data instanceof Number) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedInteger(((Number) data).longValue()));
+      } else {
+        //We continue with the original converting method (bigint) since we have an unsigned Integer
+        r.deliver(convertBigInt(column, fieldDefn, data));
+      }
+    });
+  }
+
+  /**
+   * Convert the a value representing a Unsigned BIGINT value to the correct Unsigned INT representation.
+   *
+   * @param column the column in which the value appears
+   * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+   * @param data the data; may be null
+   *
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   *
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertUnsignedBigint(Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, 0L, (r) -> {
+      if (data instanceof BigDecimal) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedBigint((BigDecimal) data));
+      } else if (data instanceof Number) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedBigint(new BigDecimal(((Number) data).toString())));
+      } else if (data instanceof String) {
+        r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedBigint(new BigDecimal((String) data)));
+      } else {
+        r.deliver(convertNumeric(column, fieldDefn, data));
+      }
+    });
+  }
+
+  /**
+   * Converts a value object for an expected type of {@link java.time.Duration} to {@link Long} values that represents
+   * the time in microseconds.
+   * <p>
+   * Per the JDBC specification, databases should return {@link java.sql.Time} instances, but that's not working
+   * because it can only handle Daytime 00:00:00-23:59:59. We use {@link java.time.Duration} instead that can handle
+   * the range of -838:59:59.000000 to 838:59:59.000000 of a MySQL TIME type and transfer data as signed INT64 which
+   * reflects the DB value converted to microseconds.
+   *
+   * @param column the column definition describing the {@code data} value; never null
+   * @param fieldDefn the field definition; never null
+   * @param data the data object to be converted into a {@link java.time.Duration} type; never null
+   * @return the converted value, or null if the conversion could not be made and the column allows nulls
+   * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
+   */
+  protected Object convertDurationToMicroseconds(Column column, Field fieldDefn, Object data) {
+    return convertValue(column, fieldDefn, data, 0L, (r) -> {
+      try {
+        if (data instanceof Duration) {
+          r.deliver(((Duration) data).toNanos() / 1_000);
+        }
+      } catch (IllegalArgumentException e) {
+      }
+    });
+  }
+
+  protected Object convertTimestampToLocalDateTime(Column column, Field fieldDefn, Object data) {
+    if (data == null && !fieldDefn.schema().isOptional()) {
+      return null;
+    }
+    if (!(data instanceof Timestamp)) {
+      return data;
+    }
+
+    return ((Timestamp) data).toLocalDateTime();
+  }
+
+  public static Duration stringToDuration(String timeString) {
+    Matcher matcher = TIME_FIELD_PATTERN.matcher(timeString);
+    if (!matcher.matches()) {
+      throw new RuntimeException("Unexpected format for TIME column: " + timeString);
+    }
+
+    long hours = Long.parseLong(matcher.group(1));
+    long minutes = Long.parseLong(matcher.group(2));
+    long seconds = Long.parseLong(matcher.group(3));
+    long nanoSeconds = 0;
+    String microSecondsString = matcher.group(5);
+    if (microSecondsString != null) {
+      nanoSeconds = Long.parseLong(Strings.justifyLeft(microSecondsString, 9, '0'));
+    }
+
+    if (hours >= 0) {
+      return Duration.ofHours(hours)
+        .plusMinutes(minutes)
+        .plusSeconds(seconds)
+        .plusNanos(nanoSeconds);
+    } else {
+      return Duration.ofHours(hours)
+        .minusMinutes(minutes)
+        .minusSeconds(seconds)
+        .minusNanos(nanoSeconds);
+    }
+  }
+}

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -65,9 +65,12 @@ public class MySqlValueConverters extends JdbcValueConverters {
    */
   private static final Pattern TIME_FIELD_PATTERN = Pattern.compile("(\\-?[0-9]*):([0-9]*):([0-9]*)(\\.([0-9]*))?");
 
-  // This is a change from the original file. It's a hacky way for us to intentionally pass in the jdbc class loader
-  // to load 'com.mysql.cj.CharsetMapping' class so that we can invoke the 'getJavaEncodingForMysqlCharset' static
-  // method.
+  /**
+   * ===================== This is a diff from the original file ===========================
+   * It's a hacky way for us to intentionally pass in the jdbc class loader to load 'com.mysql.cj.CharsetMapping'
+   * class so that we can invoke the 'getJavaEncodingForMysqlCharset' static method. The usage of this class loader
+   * is in 'charsetFor(Column column) ' method from line 320 to 329.
+   */
   public static ClassLoader jdbcClassLoader;
 
   /**
@@ -313,6 +316,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
       logger.warn("Column is missing a character set: {}", column);
       return null;
     }
+
+    // This is a change from the original file, we are using the jdbcClassLoader to invoke the static method.
     String encoding;
     try {
       encoding = (String) jdbcClassLoader.loadClass("com.mysql.cj.CharsetMapping")

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -37,4 +37,9 @@
   <suppress checks=".*" files=".*[/\\]LocalJobRunnerWithFix.java" />
   <suppress checks=".*" files=".*[/\\]org[/\\]apache[/\\]hadoop[/\\]util[/\\]Shell.java" />
 
+  <!-- Do not delete, intentionally suppress the 'MethodName' and 'StaticVariableName' checks
+    for MySqlConnectorConfig.java file, because we do not want to change the static method and variable name -->
+  <suppress checks="MethodNameCheck" files="MySqlConnectorConfig.java" />
+  <suppress checks="StaticVariableNameCheck" files="MySqlConnectorConfig.java" />
+
 </suppressions>


### PR DESCRIPTION
This PR is used to exclude mysql-jdbc jar from MySql delta source dependencies and load mysql-jdbc class into class loader at runtime. 

The hacky thing is that debezium have total three classes which require importing mysql-jdbc driver classes, and they are 'MySqlConnectorConfig', 'MySqlJdbcContext' and 'MySqlValueConverters'. In order to solve this problem, we use a short-term solution to copy all these files into our plugin package and pass in the jdbc class loader to init jdbc connection. By using this way, debezium side will use the classes we defined instead of using its own. 