### PR TITLE
CDAP-16375 Add snapshot status support for MySQL Plugin

### DIFF
--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
@@ -121,7 +121,7 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
       // This should not happen, 'source' is a mandatory field in sourceRecord from debezium
       return;
     }
-    boolean isSnapshot = Boolean.TRUE.equals(source.get("snapshot"));
+    boolean isSnapshot = Boolean.TRUE.equals(source.get(MySqlConstantOffsetBackingStore.SNAPSHOT));
     if (ddl != null) {
       ddlParser.getDdlChanges().reset();
       ddlParser.parse(ddl, tables);


### PR DESCRIPTION
1. Added snapshot status into DML/DDL events.
2. Added snapshot status into offsets and wrote to disk.
3. Refactor the existing offset store code to make it more understandable.  

Testing:
Tested on local, snapshot status and offset storage works as expected. 