### PR TITLE
CDAP16373 Add change event filtering and column dropping feature for mysql plugin.

### DIFF
--- a/delta-plugins-common/src/main/java/io/cdap/delta/common/Records.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/common/Records.java
@@ -62,6 +62,30 @@ public class Records {
   }
 
   /**
+   * Return the schema of a table.
+   *
+   * @param table
+   * @param converters
+   * @param columns
+   * @return
+   */
+  public static Schema getSchema(Table table, JdbcValueConverters converters, Set<SourceColumn> columns) {
+    // If columns set is empty, it means user wants to have all the columns by default.
+    if (columns.isEmpty()) {
+      return getSchema(table, converters);
+    }
+
+    List<Schema.Field> fields = new ArrayList<>(columns.size());
+    for (SourceColumn column : columns) {
+      String columnName = column.getName();
+      fields.add(Schema.Field.of(columnName,
+                                 convert(converters.schemaBuilder(table.columnWithName(columnName)).build())));
+    }
+
+    return Schema.recordOf(table.id().table(), fields);
+  }
+
+  /**
    * Return a new structured record which will only contain selected columns for the table.
    *
    * @param record

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
@@ -118,7 +118,8 @@ public class MySqlEventReader implements EventReader {
       // Create the engine with this configuration ...
       engine = EmbeddedEngine.create()
         .using(debeziumConf)
-        .notifying(new MySqlRecordConsumer(context, emitter, ddlParser, mySqlValueConverters, new Tables()))
+        .notifying(new MySqlRecordConsumer(context, emitter, ddlParser, mySqlValueConverters,
+                                           new Tables(), sourceTableMap))
         .using(new NotifyingCompletionCallback(context))
         .build();
       executorService.submit(engine);

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
@@ -24,6 +24,7 @@ import io.cdap.delta.api.DMLOperation;
 import io.cdap.delta.api.DeltaSourceContext;
 import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.Offset;
+import io.cdap.delta.api.SourceTable;
 import io.cdap.delta.common.Records;
 import io.debezium.connector.mysql.MySqlValueConverters;
 import io.debezium.relational.Table;
@@ -52,15 +53,17 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
   private final DdlParser ddlParser;
   private final MySqlValueConverters mySqlValueConverters;
   private final Tables tables;
+  private final Map<String, SourceTable> sourceTableMap;
 
   public MySqlRecordConsumer(DeltaSourceContext context, EventEmitter emitter,
                              DdlParser ddlParser, MySqlValueConverters mySqlValueConverters,
-                             Tables tables) {
+                             Tables tables, Map<String, SourceTable> sourceTableMap) {
     this.context = context;
     this.emitter = emitter;
     this.ddlParser = ddlParser;
     this.mySqlValueConverters = mySqlValueConverters;
     this.tables = tables;
+    this.sourceTableMap = sourceTableMap;
   }
 
   @Override
@@ -122,46 +125,63 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
       return;
     }
     boolean isSnapshot = Boolean.TRUE.equals(source.get(MySqlConstantOffsetBackingStore.SNAPSHOT));
+    // If the map is empty, we should read all DDL/DML events and columns of all tables
+    boolean readAllTables = sourceTableMap.isEmpty();
+
     if (ddl != null) {
       ddlParser.getDdlChanges().reset();
       ddlParser.parse(ddl, tables);
-      ddlParser.getDdlChanges().groupEventsByDatabase((databaseName, events) -> {
+      ddlParser.getDdlChanges().groupEventsByDatabase((database, events) -> {
         for (DdlParserListener.Event event : events) {
           DDLEvent.Builder builder = DDLEvent.builder()
-            .setDatabase(databaseName)
+            .setDatabase(database)
             .setOffset(recordOffset)
             .setSnapshot(isSnapshot);
+          // since current ddl blacklist implementation is bind with table level, we will only do the dll blacklist
+          // checking only for table change related ddl event(ALTER_TABLE/DROP_TABLE/CREATE_TABLE/TRUNCATE_TABLE).
           switch (event.type()) {
             case ALTER_TABLE:
               DdlParserListener.TableAlteredEvent alteredEvent = (DdlParserListener.TableAlteredEvent) event;
+              TableId tableId = alteredEvent.tableId();
+              Table table = tables.forTable(tableId);
+              SourceTable sourceTable = getSourceTable(database, tableId.table());
+
               if (alteredEvent.previousTableId() != null) {
                 builder.setOperation(DDLOperation.RENAME_TABLE)
                   .setPrevTable(alteredEvent.previousTableId().table());
               } else {
                 builder.setOperation(DDLOperation.ALTER_TABLE);
               }
-              TableId tableId = alteredEvent.tableId();
-              Table table = tables.forTable(tableId);
               emitter.emit(builder.setTable(tableId.table())
-                             .setSchema(Records.getSchema(table, mySqlValueConverters))
+                             .setSchema(readAllTables ? Records.getSchema(table, mySqlValueConverters) :
+                                          Records.getSchema(table, mySqlValueConverters, sourceTable.getColumns()))
                              .setPrimaryKey(table.primaryKeyColumnNames())
                              .build());
               break;
             case DROP_TABLE:
               DdlParserListener.TableDroppedEvent droppedEvent = (DdlParserListener.TableDroppedEvent) event;
-              emitter.emit(builder.setOperation(DDLOperation.DROP_TABLE)
-                             .setTable(droppedEvent.tableId().table())
-                             .build());
+              sourceTable = getSourceTable(database, droppedEvent.tableId().table());
+              if (!sourceTableNotValid(readAllTables, sourceTable) &&
+                !isDDLOperationBlacklisted(readAllTables, sourceTable, DDLOperation.DROP_TABLE)) {
+                emitter.emit(builder.setOperation(DDLOperation.DROP_TABLE)
+                               .setTable(droppedEvent.tableId().table())
+                               .build());
+              }
               break;
             case CREATE_TABLE:
               DdlParserListener.TableCreatedEvent createdEvent = (DdlParserListener.TableCreatedEvent) event;
               tableId = createdEvent.tableId();
               table = tables.forTable(tableId);
-              emitter.emit(builder.setOperation(DDLOperation.CREATE_TABLE)
-                             .setTable(tableId.table())
-                             .setSchema(Records.getSchema(table, mySqlValueConverters))
-                             .setPrimaryKey(table.primaryKeyColumnNames())
-                             .build());
+              sourceTable = getSourceTable(database, tableId.table());
+              if (!sourceTableNotValid(readAllTables, sourceTable) &&
+                !isDDLOperationBlacklisted(readAllTables, sourceTable, DDLOperation.CREATE_TABLE)) {
+                emitter.emit(builder.setOperation(DDLOperation.CREATE_TABLE)
+                               .setTable(tableId.table())
+                               .setSchema(readAllTables ? Records.getSchema(table, mySqlValueConverters) :
+                                            Records.getSchema(table, mySqlValueConverters, sourceTable.getColumns()))
+                               .setPrimaryKey(table.primaryKeyColumnNames())
+                               .build());
+              }
               break;
             case DROP_DATABASE:
               emitter.emit(builder.setOperation(DDLOperation.DROP_DATABASE).build());
@@ -172,15 +192,26 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
             case TRUNCATE_TABLE:
               DdlParserListener.TableTruncatedEvent truncatedEvent =
                 (DdlParserListener.TableTruncatedEvent) event;
-              emitter.emit(builder.setOperation(DDLOperation.TRUNCATE_TABLE)
-                             .setTable(truncatedEvent.tableId().table())
-                             .build());
+              sourceTable = getSourceTable(database, truncatedEvent.tableId().table());
+              if (!sourceTableNotValid(readAllTables, sourceTable) &&
+                !isDDLOperationBlacklisted(readAllTables, sourceTable, DDLOperation.TRUNCATE_TABLE)) {
+                emitter.emit(builder.setOperation(DDLOperation.TRUNCATE_TABLE)
+                               .setTable(truncatedEvent.tableId().table())
+                               .build());
+              }
               break;
             default:
               return;
           }
         }
       });
+      return;
+    }
+
+    String databaseName = source.get("db");
+    String tableName = source.get("table");
+    SourceTable sourceTable = getSourceTable(databaseName, tableName);
+    if (sourceTableNotValid(readAllTables, sourceTable)) {
       return;
     }
 
@@ -196,8 +227,12 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
       LOG.warn("Skipping unknown operation type '{}'", opStr);
       return;
     }
-    String database = source.get("db");
-    String table = source.get("table");
+
+    if (!readAllTables && sourceTable.getDmlBlacklist().contains(op)) {
+      // do nothing due to it was not set to read all tables and the DML op has been blacklisted for this table
+      return;
+    }
+
     String transactionId = source.get("gtid");
     if (transactionId == null) {
       // this is not really a transaction id, but we don't get an event when a transaction started/ended
@@ -208,12 +243,21 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
 
     StructuredRecord before = val.get("before");
     StructuredRecord after = val.get("after");
+    if (!readAllTables) {
+      if (before != null) {
+        before = Records.keepSelectedColumns(before, sourceTable.getColumns());
+      }
+      if (after != null) {
+        after = Records.keepSelectedColumns(after, sourceTable.getColumns());
+      }
+    }
+
     Long ingestTime = val.get("ts_ms");
     DMLEvent.Builder builder = DMLEvent.builder()
       .setOffset(recordOffset)
       .setOperation(op)
-      .setDatabase(database)
-      .setTable(table)
+      .setDatabase(databaseName)
+      .setTable(tableName)
       .setTransactionId(transactionId)
       .setIngestTimestamp(ingestTime)
       .setSnapshot(isSnapshot);
@@ -226,6 +270,22 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
     } else {
       emitter.emit(builder.setRow(after).build());
     }
+  }
+
+  private boolean isDDLOperationBlacklisted(boolean readAllTables, SourceTable sourceTable, DDLOperation op) {
+    // return true if record consumer was not set to read all table events and the DDL op has been
+    // blacklisted for this table
+    return !readAllTables && sourceTable.getDdlBlacklist().contains(op);
+  }
+
+  private boolean sourceTableNotValid(boolean readAllTables, SourceTable sourceTable) {
+    // this should not happen, in this case, just return the result here and let caller to handle
+    return !readAllTables && sourceTable == null;
+  }
+
+  private SourceTable getSourceTable(String database, String table) {
+    String sourceTableId = database + "." + table;
+    return sourceTableMap.get(sourceTableId);
   }
 
   // This method is used for generating a cdap offsets from debezium sourceRecord.


### PR DESCRIPTION
This PR is for adding feature of DDL/DML event filtering and Column dropping for MySQL plugin. 

One thing needs to be called out here, for DDL event filtering, since our current ddlBlacklist is bind with source table, so that table id is required for that. So, we could not filter all the dll events, we will only support table related dll event in this iteration. 