### PR TITLE
[CDAP-16397] Emit DROP_TABLE event before snapshotting the unseen table for SqlServer Plugin.

### DIFF
--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
@@ -147,6 +147,11 @@ public class SqlServerRecordConsumer implements Consumer<SourceRecord> {
         primaryFields = fields.stream().map(Schema.Field::getName).collect(Collectors.toList());
       }
 
+      // try to always drop the table before snapshot the schema.
+      emitter.emit(builder.setOperation(DDLOperation.DROP_TABLE)
+                     .setTable(tableName)
+                     .build());
+
       emitter.emit(builder.setOperation(DDLOperation.CREATE_TABLE)
                      .setTable(tableName)
                      .setSchema(schema)


### PR DESCRIPTION
This is a bugfix that we should always try to emitt drop table events for unseen tables before start snapshotting it. If not, there will be errors when we changed the schema of the table and use another replicator to replicate the events. 