### PR TITLE
[cdap-16409] Fix an issue that mysql delta source can not restart correctly from stored offset.

### DIFF
--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConstantOffsetBackingStore.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConstantOffsetBackingStore.java
@@ -39,6 +39,10 @@ public class MySqlConstantOffsetBackingStore extends MemoryOffsetBackingStore {
   static final String FILE = "file";
   static final String POS = "pos";
   static final String SNAPSHOT = "snapshot";
+  static final String ROW = "row";
+  static final String EVENT = "event";
+  static final String GTID_SET = "gtids";
+
   private static final Gson GSON = new Gson();
   // The key is hardcoded here
   private static final ByteBuffer KEY =
@@ -50,6 +54,9 @@ public class MySqlConstantOffsetBackingStore extends MemoryOffsetBackingStore {
     String fileStr = originalConfig.get(FILE);
     String posStr = originalConfig.get(POS);
     String snapshotStr = originalConfig.get(SNAPSHOT);
+    String rowStr = originalConfig.get(ROW);
+    String eventStr = originalConfig.get(EVENT);
+    String gtidSetStr = originalConfig.get(GTID_SET);
 
     Map<String, Object> offset = new HashMap<>();
     if (!Strings.isNullOrEmpty(fileStr)) {
@@ -60,6 +67,15 @@ public class MySqlConstantOffsetBackingStore extends MemoryOffsetBackingStore {
     }
     if (!Strings.isNullOrEmpty(snapshotStr)) {
       offset.put(SNAPSHOT, Boolean.valueOf(snapshotStr));
+    }
+    if (!Strings.isNullOrEmpty(rowStr)) {
+      offset.put(ROW, Long.valueOf(rowStr));
+    }
+    if (!Strings.isNullOrEmpty(eventStr)) {
+      offset.put(EVENT, Long.valueOf(eventStr));
+    }
+    if (!Strings.isNullOrEmpty(gtidSetStr)) {
+      offset.put(GTID_SET, gtidSetStr);
     }
 
     if (offset.isEmpty()) {

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConstantOffsetBackingStore.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConstantOffsetBackingStore.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * OffsetBackingStore is pretty weird... keys are ByteBuffer representations of Strings like:
  * {"schema":null,"payload":["delta",{"server":"dummy"}]}
  *
- * and values will contain following items: 1. file; 2. pos; 3. snapshot.
+ * and values will contain following items: 1. file; 2. pos; 3. snapshot; 4. row; 5. event; 6. gtids.
  */
 public class MySqlConstantOffsetBackingStore extends MemoryOffsetBackingStore {
   static final String FILE = "file";

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
@@ -93,6 +93,9 @@ public class MySqlEventReader implements EventReader {
       .with("file", state.getOrDefault(MySqlConstantOffsetBackingStore.FILE, ""))
       .with("pos", state.getOrDefault(MySqlConstantOffsetBackingStore.POS, ""))
       .with("snapshot", state.getOrDefault(MySqlConstantOffsetBackingStore.SNAPSHOT, ""))
+      .with("row", state.getOrDefault(MySqlConstantOffsetBackingStore.ROW, ""))
+      .with("event", state.getOrDefault(MySqlConstantOffsetBackingStore.EVENT, ""))
+      .with("gtids", state.getOrDefault(MySqlConstantOffsetBackingStore.GTID_SET, ""))
       /* begin connector properties */
       .with("name", "delta")
       .with("database.hostname", config.getHost())

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
@@ -298,19 +298,13 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
   // This method is used for generating a cdap offsets from debezium sourceRecord.
   private Map<String, String> generateCdapOffsets(SourceRecord sourceRecord) {
     Map<String, String> deltaOffset = new HashMap<>();
-    Struct value = (Struct) sourceRecord.value();
-    if (value == null) { // safety check to avoid NPE
-      return deltaOffset;
-    }
-
-    Struct source = (Struct) value.get("source");
-    if (source == null) { // safety check to avoid NPE
-      return deltaOffset;
-    }
-
-    String binlogFile = (String) source.get(MySqlConstantOffsetBackingStore.FILE);
-    Long binlogPosition = (Long) source.get(MySqlConstantOffsetBackingStore.POS);
-    Boolean snapshot = (Boolean) source.get(MySqlConstantOffsetBackingStore.SNAPSHOT);
+    Map<String, ?> sourceOffset = sourceRecord.sourceOffset();
+    String binlogFile = (String) sourceOffset.get(MySqlConstantOffsetBackingStore.FILE);
+    Long binlogPosition = (Long) sourceOffset.get(MySqlConstantOffsetBackingStore.POS);
+    Boolean snapshot = (Boolean) sourceOffset.get(MySqlConstantOffsetBackingStore.SNAPSHOT);
+    Long rowsToSkip = (Long) sourceOffset.get(MySqlConstantOffsetBackingStore.ROW);
+    Long eventsToSkip = (Long) sourceOffset.get(MySqlConstantOffsetBackingStore.EVENT);
+    String gtidSet = (String) sourceOffset.get(MySqlConstantOffsetBackingStore.GTID_SET);
 
     if (binlogFile != null) {
       deltaOffset.put(MySqlConstantOffsetBackingStore.FILE, binlogFile);
@@ -320,6 +314,15 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
     }
     if (snapshot != null) {
       deltaOffset.put(MySqlConstantOffsetBackingStore.SNAPSHOT, String.valueOf(snapshot));
+    }
+    if (rowsToSkip != null) {
+      deltaOffset.put(MySqlConstantOffsetBackingStore.ROW, String.valueOf(rowsToSkip));
+    }
+    if (eventsToSkip != null) {
+      deltaOffset.put(MySqlConstantOffsetBackingStore.EVENT, String.valueOf(eventsToSkip));
+    }
+    if (gtidSet != null) {
+      deltaOffset.put(MySqlConstantOffsetBackingStore.GTID_SET, gtidSet);
     }
 
     return deltaOffset;


### PR DESCRIPTION
This is for fixing an issue that mysql delta source can not restart correctly from stored offset.
Issues are two parts.
1. We need to also persist additional three configs into offset.
 "row" => restart row to skip
 "event" => restart event to skip
 "gtids" => gtids set (Good to have if user turned on the gtid_mode)

2. The original binlog position was read from source metadata bind with source record which is incorrect; for mysql, we should use all the information came from sourceOffset obj. 

Testing: tested locally, restarts works as expected. 