### PR TITLE
CDAP-16468 Mark GEOMETRY and GEOGRAPHY as NOT supported in Sql Server Assessor

### DIFF
--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableAssessor.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableAssessor.java
@@ -39,6 +39,9 @@ import java.util.Map;
 public class SqlServerTableAssessor implements TableAssessor<TableDetail> {
   static final String COLUMN_LENGTH = "COLUMN_LENGTH";
   static final String SCALE = "SCALE";
+  static final String TYPE_NAME = "TYPE_NAME";
+  private static final String GEOMETRY = "GEOMETRY";
+  private static final String GEOGRAPHY = "GEOGRAPHY";
 
   @Override
   public TableAssessment assess(TableDetail tableDetail) {
@@ -119,6 +122,15 @@ public class SqlServerTableAssessor implements TableAssessor<TableDetail> {
       case Types.BINARY:
       case Types.VARBINARY:
       case Types.LONGVARBINARY:
+        properties = detail.getProperties();
+        String upperCaseTypeName = properties.get(TYPE_NAME).toUpperCase();
+        if (GEOGRAPHY.equals(upperCaseTypeName) || GEOMETRY.equals(upperCaseTypeName)) {
+          support = ColumnSupport.NO;
+          suggestion = new ColumnSuggestion("Unsupported SQL Server Type: " + upperCaseTypeName,
+                                            Collections.emptyList());
+          schema = null;
+          break;
+        }
         schema = Schema.of(Schema.Type.BYTES);
         break;
 

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableRegistry.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableRegistry.java
@@ -166,6 +166,7 @@ public class SqlServerTableRegistry implements TableRegistry {
         Map<String, String> properties = new HashMap<>();
         properties.put(SqlServerTableAssessor.COLUMN_LENGTH, columnResults.getString("COLUMN_SIZE"));
         properties.put(SqlServerTableAssessor.SCALE, columnResults.getString("DECIMAL_DIGITS"));
+        properties.put(SqlServerTableAssessor.TYPE_NAME, columnResults.getString("TYPE_NAME"));
         schemaName = columnResults.getString("TABLE_SCHEM");
         columns.add(new ColumnDetail(columnResults.getString("COLUMN_NAME"),
                                      JDBCType.valueOf(columnResults.getInt("DATA_TYPE")),


### PR DESCRIPTION
geometry and geography data type are not supported in debezium sql server connector so far, so we will mark them as NO supported during assessment. One thing needs to call out, the geometry and geography sql server data type will be mapped to VARBINARY JDBC data type, that is why we want to pick them out and mark them as unsupported during assessment to avoid confusion. 