### PR TITLE
Add default timezone as 'UTC' for SqlServer delta plugin.

### DIFF
--- a/sqlserver-delta-plugins/widgets/sqlserver-cdcSource.json
+++ b/sqlserver-delta-plugins/widgets/sqlserver-cdcSource.json
@@ -53,7 +53,10 @@
         {
           "name": "serverTimezone",
           "label": "Server Timezone",
-          "widget-type": "textbox"
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "default": "UTC"
+          }
         }
       ]
     }


### PR DESCRIPTION
Add default timezone as 'UTC' for SqlServer delta plugin.