### PR TITLE
CDAP-16547 Remove missing primary key assessment in DB delta sources.

### DIFF
--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlTableAssessor.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlTableAssessor.java
@@ -21,7 +21,6 @@ import io.cdap.delta.api.assessment.ColumnAssessment;
 import io.cdap.delta.api.assessment.ColumnDetail;
 import io.cdap.delta.api.assessment.ColumnSuggestion;
 import io.cdap.delta.api.assessment.ColumnSupport;
-import io.cdap.delta.api.assessment.Problem;
 import io.cdap.delta.api.assessment.TableAssessment;
 import io.cdap.delta.api.assessment.TableAssessor;
 import io.cdap.delta.api.assessment.TableDetail;
@@ -47,15 +46,7 @@ public class MySqlTableAssessor implements TableAssessor<TableDetail> {
       columnAssessments.add(evaluateColumn(columnDetail).getAssessment());
     }
 
-    List<Problem> problems = new ArrayList<>(tableDetail.getFeatures());
-    if (tableDetail.getPrimaryKey().isEmpty()) {
-      problems.add(new Problem("Missing Primary Key",
-                               String.format("Table '%s' in database '%s' must have a primary key in order to be " +
-                                               "replicated.", tableDetail.getTable(), tableDetail.getDatabase()),
-                               "Please alter the table to use a primary key, or select a different table",
-                               "Not able to replicate this table"));
-    }
-    return new TableAssessment(columnAssessments, problems);
+    return new TableAssessment(columnAssessments, tableDetail.getFeatures());
   }
 
   // This is based on https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-type-conversions.html

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableAssessor.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableAssessor.java
@@ -21,7 +21,6 @@ import io.cdap.delta.api.assessment.ColumnAssessment;
 import io.cdap.delta.api.assessment.ColumnDetail;
 import io.cdap.delta.api.assessment.ColumnSuggestion;
 import io.cdap.delta.api.assessment.ColumnSupport;
-import io.cdap.delta.api.assessment.Problem;
 import io.cdap.delta.api.assessment.TableAssessment;
 import io.cdap.delta.api.assessment.TableAssessor;
 import io.cdap.delta.api.assessment.TableDetail;
@@ -50,15 +49,7 @@ public class SqlServerTableAssessor implements TableAssessor<TableDetail> {
       columnAssessments.add(evaluateColumn(columnDetail).getAssessment());
     }
 
-    List<Problem> problems = new ArrayList<>(tableDetail.getFeatures());
-    if (tableDetail.getPrimaryKey().isEmpty()) {
-      problems.add(new Problem("Missing Primary Key",
-                               String.format("Table '%s' in database '%s' must have a primary key in order to be " +
-                                               "replicated.", tableDetail.getTable(), tableDetail.getDatabase()),
-                               "Please alter the table to use a primary key, or select a different table",
-                               "Not able to replicate this table"));
-    }
-    return new TableAssessment(columnAssessments, problems);
+    return new TableAssessment(columnAssessments, tableDetail.getFeatures());
   }
 
   // This is based on https://docs.microsoft.com/en-us/sql/connect/jdbc/using-basic-data-types?view=sql-server-ver15


### PR DESCRIPTION
From the perspective of the source, it's not actually a feature problem if the target is able to handle events without a primary key. We will remove this logic from the source plugins.

Tested on local, shows up only one missing feature from BQ side. 