### PR TITLE
CDAP-16570 Fix the issue that primary keys were not read correctly from SQL-SERVER.

### DIFF
--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableRegistry.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableRegistry.java
@@ -116,7 +116,7 @@ public class SqlServerTableRegistry implements TableRegistry {
               new Problem("Table CDC Feature Not Enabled",
                           String.format("The CDC feature for table '%s' in database '%s' was not enabled.", table, db),
                           "Check the table CDC settings",
-                          null));
+                          "Not able to replicate table changes"));
           }
         }
       } catch (Exception e) {
@@ -178,7 +178,7 @@ public class SqlServerTableRegistry implements TableRegistry {
       return Optional.empty();
     }
     List<String> primaryKey = new ArrayList<>();
-    try (ResultSet keyResults = dbMeta.getPrimaryKeys(db, null, table)) {
+    try (ResultSet keyResults = dbMeta.getPrimaryKeys(db, schemaName, table)) {
       while (keyResults.next()) {
         primaryKey.add(keyResults.getString("COLUMN_NAME"));
       }


### PR DESCRIPTION
It turns out schema name is needed to get primary keys from dbMetadata.

Tested with AdvantureWorks17 database, primary keys were show up correctly as expected.