### PR TITLE
CDAP-16554 check replication permissions during assessment for MySQL.

### DIFF
--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.plugin.PluginConfig;
 
+import java.util.Properties;
 import javax.annotation.Nullable;
 
 /**
@@ -97,5 +98,17 @@ public class MySqlConfig extends PluginConfig {
 
   public String getJDBCPluginId() {
     return String.format("%s.%s.%s", "mysqlsource", "jbdc", jdbcPluginName);
+  }
+
+  public String getJdbcURL() {
+    return String.format("jdbc:mysql://%s:%d/%s", host, port, database);
+  }
+
+  public Properties getConnectionProperties() {
+    Properties properties = new Properties();
+    properties.put("user", user);
+    properties.put("password", password);
+    properties.put("serverTimezone", getServerTimezone());
+    return properties;
   }
 }

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlDeltaSource.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlDeltaSource.java
@@ -69,8 +69,7 @@ public class MySqlDeltaSource implements DeltaSource {
       throw new IllegalArgumentException("JDBC plugin " + conf.getJdbcPluginName() + " not found.");
     }
     try {
-      DriverCleanup cleanup = DriverCleanup.ensureJDBCDriverIsAvailable(
-        jdbcDriverClass, String.format("jdbc:mysql://%s:%d/%s", conf.getHost(), conf.getPort(), conf.getDatabase()));
+      DriverCleanup cleanup = DriverCleanup.ensureJDBCDriverIsAvailable(jdbcDriverClass, conf.getJdbcURL());
       return new MySqlTableRegistry(conf, cleanup);
     } catch (Exception e) {
       throw new RuntimeException("Unable to instantiate JDBC driver", e);
@@ -79,6 +78,6 @@ public class MySqlDeltaSource implements DeltaSource {
 
   @Override
   public TableAssessor<TableDetail> createTableAssessor(Configurer configurer) throws Exception {
-    return new MySqlTableAssessor();
+    return new MySqlTableAssessor(conf);
   }
 }

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlDeltaSource.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlDeltaSource.java
@@ -62,24 +62,16 @@ public class MySqlDeltaSource implements DeltaSource {
   }
 
   @Override
-  public TableRegistry createTableRegistry(Configurer configurer) {
-    Class<? extends Driver> jdbcDriverClass = configurer.usePluginClass("jdbc", conf.getJdbcPluginName(),
-                                                                        conf.getJDBCPluginId() + "." +
-                                                                          UUID.randomUUID().toString(),
-                                                                        PluginProperties.builder().build());
-    if (jdbcDriverClass == null) {
-      throw new IllegalArgumentException("JDBC plugin " + conf.getJdbcPluginName() + " not found.");
-    }
-    try {
-      DriverCleanup cleanup = DriverCleanup.ensureJDBCDriverIsAvailable(jdbcDriverClass, conf.getJdbcURL());
-      return new MySqlTableRegistry(conf, cleanup);
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to instantiate JDBC driver", e);
-    }
+  public TableRegistry createTableRegistry(Configurer configurer) throws Exception {
+    return new MySqlTableRegistry(conf, getDriverCleanup(configurer));
   }
 
   @Override
   public TableAssessor<TableDetail> createTableAssessor(Configurer configurer) throws Exception {
+    return new MySqlTableAssessor(conf, getDriverCleanup(configurer));
+  }
+
+  private DriverCleanup getDriverCleanup(Configurer configurer) throws Exception {
     Class<? extends Driver> jdbcDriverClass = configurer.usePluginClass("jdbc", conf.getJdbcPluginName(),
                                                                         conf.getJDBCPluginId() + "." +
                                                                           UUID.randomUUID().toString(),
@@ -87,11 +79,7 @@ public class MySqlDeltaSource implements DeltaSource {
     if (jdbcDriverClass == null) {
       throw new IllegalArgumentException("JDBC plugin " + conf.getJdbcPluginName() + " not found.");
     }
-    try {
-      DriverCleanup cleanup = DriverCleanup.ensureJDBCDriverIsAvailable(jdbcDriverClass, conf.getJdbcURL());
-      return new MySqlTableAssessor(conf, cleanup);
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to instantiate JDBC driver", e);
-    }
+
+    return DriverCleanup.ensureJDBCDriverIsAvailable(jdbcDriverClass, conf.getJdbcURL());
   }
 }

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlTableAssessor.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlTableAssessor.java
@@ -171,6 +171,9 @@ public class MySqlTableAssessor implements TableAssessor<TableDetail> {
          ResultSet rs = statement.executeQuery(query)) {
       if (rs.next()) {
         String grants = rs.getString(1);
+
+        // Avoid potential NPE in case the connection was accidentally closed by database before the value is read,
+        // though it will happen very rarely
         if (grants == null) {
           featureProblems.add(permissionUnknownProblem);
           return;

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlTableAssessor.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlTableAssessor.java
@@ -47,8 +47,8 @@ public class MySqlTableAssessor implements TableAssessor<TableDetail> {
   static final String COLUMN_LENGTH = "COLUMN_LENGTH";
   static final String SCALE = "SCALE";
 
-  private final DriverCleanup driverCleanup;
   private final MySqlConfig conf;
+  private final DriverCleanup driverCleanup;
 
   MySqlTableAssessor(MySqlConfig conf, DriverCleanup driverCleanup) {
     this.conf = conf;
@@ -188,8 +188,7 @@ public class MySqlTableAssessor implements TableAssessor<TableDetail> {
                                         conf.getUser(), conf.getHost()),
                           String.format("Grant '%s' permission to user '%s'@'%s'", permission,
                                         conf.getUser(), conf.getHost()),
-                          "The accounts that are used by slave servers were not able to connect to the " +
-                            "current server as their master"));
+                          "Will not be able to read replication events after the initial snapshot completes."));
           }
         }
       }

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlTableRegistry.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlTableRegistry.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 
 /**
  * Lists and describes tables.
@@ -48,21 +47,17 @@ import java.util.Properties;
 public class MySqlTableRegistry implements TableRegistry {
   private final MySqlConfig conf;
   private final DriverCleanup driverCleanup;
-  private final Properties properties;
 
   public MySqlTableRegistry(MySqlConfig conf, DriverCleanup driverCleanup) {
     this.conf = conf;
     this.driverCleanup = driverCleanup;
-    this.properties = new Properties();
-    properties.put("user", conf.getUser());
-    properties.put("password", conf.getPassword());
-    properties.put("serverTimezone", conf.getServerTimezone());
   }
 
   @Override
   public TableList listTables() throws IOException {
     List<TableSummary> tables = new ArrayList<>();
-    try (Connection connection = DriverManager.getConnection(getConnectionString(conf.getDatabase()), properties)) {
+    try (Connection connection = DriverManager.getConnection(getConnectionString(conf.getDatabase()),
+                                                             conf.getConnectionProperties())) {
       DatabaseMetaData dbMeta = connection.getMetaData();
       try (ResultSet tableResults = dbMeta.getTables(null, null, null, null)) {
         while (tableResults.next()) {
@@ -85,7 +80,7 @@ public class MySqlTableRegistry implements TableRegistry {
 
   @Override
   public TableDetail describeTable(String db, String table) throws TableNotFoundException, IOException {
-    try (Connection connection = DriverManager.getConnection(getConnectionString(db), properties)) {
+    try (Connection connection = DriverManager.getConnection(getConnectionString(db), conf.getConnectionProperties())) {
       DatabaseMetaData dbMeta = connection.getMetaData();
       TableDetail.Builder builder = getTableDetailBuilder(dbMeta, db, table)
         .orElseThrow(() -> new TableNotFoundException(db, table, ""));

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerDeltaSource.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerDeltaSource.java
@@ -60,20 +60,17 @@ public class SqlServerDeltaSource implements DeltaSource {
   }
 
   @Override
-  public TableRegistry createTableRegistry(Configurer configurer) {
+  public TableRegistry createTableRegistry(Configurer configurer) throws Exception {
     Class<? extends Driver> jdbcDriverClass = configurer.usePluginClass("jdbc", config.getJdbcPluginName(),
                                                                         config.getJDBCPluginId(),
                                                                         PluginProperties.builder().build());
     if (jdbcDriverClass == null) {
       throw new IllegalArgumentException("JDBC plugin " + config.getJdbcPluginName() + " not found.");
     }
-    try {
-      DriverCleanup cleanup = DriverCleanup.ensureJDBCDriverIsAvailable(
-        jdbcDriverClass, String.format("jdbc:sqlserver://%s:%d", config.getHost(), config.getPort()));
-      return new SqlServerTableRegistry(config, cleanup);
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to instantiate JDBC driver", e);
-    }
+
+    DriverCleanup cleanup = DriverCleanup.ensureJDBCDriverIsAvailable(
+      jdbcDriverClass, String.format("jdbc:sqlserver://%s:%d", config.getHost(), config.getPort()));
+    return new SqlServerTableRegistry(config, cleanup);
   }
 
   @Override


### PR DESCRIPTION
The reason why added the check on the assess() method of MysqlAssessor is due to that this permission check is user level not table level. If we put it under the assess method in table level, all the problems will be duplicated per table. In addition to the change, also did some code refactor for jdbcUrl, connectionProperties and dirverCleanup.  