### PR TITLE
CDAP-16575 add option to ignore drop db and drop table events

### DIFF
--- a/mysql-delta-plugins/docs/mysql-cdcSource.md
+++ b/mysql-delta-plugins/docs/mysql-cdcSource.md
@@ -69,6 +69,10 @@ slave that is replicating from the server.
 
 **JDBC Plugin Name:** Name of the jdbc driver to use.
 
+**Drop Tables During Snapshot:** Whether to emit drop database and drop table change events at the start
+of the snapshot phase. Set this to false if you would like to avoid accidentally deleting tables in the
+target system. However, when set to false, it can result in duplicate data in the target.
+
 Troubleshooting
 -----------
 If the replicator is able to start snapshotting the data, but fails when it switches over to read from the 

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
@@ -52,6 +52,10 @@ public class MySqlConfig extends PluginConfig {
   @Description("Name of the jdbc plugin to use.")
   private String jdbcPluginName;
 
+  @Nullable
+  @Description("Whether to emit drop database and drop table events during the snapshot phase.")
+  private Boolean dropDuringSnapshot;
+
   public MySqlConfig(String host, int port, String user, String password, int consumerID,
                      String database, @Nullable String serverTimezone) {
     this.host = host;
@@ -97,5 +101,9 @@ public class MySqlConfig extends PluginConfig {
 
   public String getJDBCPluginId() {
     return String.format("%s.%s.%s", "mysqlsource", "jbdc", jdbcPluginName);
+  }
+
+  public boolean shouldDropDuringSnapshot() {
+    return dropDuringSnapshot == null ? false : dropDuringSnapshot;
   }
 }

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
@@ -122,7 +122,7 @@ public class MySqlEventReader implements EventReader {
       engine = EmbeddedEngine.create()
         .using(debeziumConf)
         .notifying(new MySqlRecordConsumer(context, emitter, ddlParser, mySqlValueConverters,
-                                           new Tables(), sourceTableMap))
+                                           new Tables(), sourceTableMap, config.shouldDropDuringSnapshot()))
         .using(new NotifyingCompletionCallback(context))
         .build();
       executorService.submit(engine);

--- a/mysql-delta-plugins/src/test/java/io/cdap/delta/mysql/MySqlEventReaderIntegrationTest.java
+++ b/mysql-delta-plugins/src/test/java/io/cdap/delta/mysql/MySqlEventReaderIntegrationTest.java
@@ -193,4 +193,5 @@ public class MySqlEventReaderIntegrationTest {
     // this fails with schemas that are different
     // Assert.assertEquals(expected, row);
   }
+
 }

--- a/mysql-delta-plugins/widgets/mysql-cdcSource.json
+++ b/mysql-delta-plugins/widgets/mysql-cdcSource.json
@@ -5,7 +5,7 @@
   "display-name": "MySQL",
   "configuration-groups": [
     {
-      "label": "Database Location",
+      "label": "Basic",
       "properties": [
         {
           "name": "host",
@@ -26,14 +26,6 @@
           "widget-type": "textbox"
         },
         {
-          "name": "serverTimezone",
-          "label": "Server Timezone",
-          "widget-type": "textbox",
-          "widget-attributes": {
-            "default": "UTC"
-          }
-        },
-        {
           "name": "database",
           "label": "Database Name",
           "widget-type": "textbox"
@@ -49,7 +41,7 @@
       ]
     },
     {
-      "label": "User Account",
+      "label": "Credentials",
       "properties": [
         {
           "name": "user",
@@ -60,6 +52,35 @@
           "name": "password",
           "label": "Password",
           "widget-type": "password"
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
+      "properties": [
+        {
+          "name": "serverTimezone",
+          "label": "Server Timezone",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "default": "UTC"
+          }
+        },
+        {
+          "name": "dropDuringSnapshot",
+          "label": "Drop Tables During Snapshot",
+          "widget-type": "toggle",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
         }
       ]
     }

--- a/sqlserver-delta-plugins/docs/sqlserver-cdcSource.md
+++ b/sqlserver-delta-plugins/docs/sqlserver-cdcSource.md
@@ -68,3 +68,7 @@ Plugin Properties
 **Database:** Database to consume events for.
 
 **JDBC Plugin Name:** Name of the jdbc driver to use.
+
+**Drop Tables During Snapshot:** Whether to emit drop database and drop table change events at the start
+of the snapshot phase. Set this to false if you would like to avoid accidentally deleting tables in the
+target system. However, when set to false, it can result in duplicate data in the target.

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConfig.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConfig.java
@@ -50,8 +50,13 @@ public class SqlServerConfig extends PluginConfig {
   @Description("Name of the jdbc plugin to use.")
   private String jdbcPluginName;
 
+  @Nullable
+  @Description("Whether to emit drop database and drop table events during the snapshot phase.")
+  private Boolean dropDuringSnapshot;
+
   public SqlServerConfig(String host, int port, String user, String password,
-                         String database, @Nullable String serverTimezone, String jdbcPluginName) {
+                         String database, @Nullable String serverTimezone, String jdbcPluginName,
+                         boolean dropDuringSnapshot) {
     this.host = host;
     this.port = port;
     this.user = user;
@@ -59,6 +64,7 @@ public class SqlServerConfig extends PluginConfig {
     this.database = database;
     this.serverTimezone = serverTimezone;
     this.jdbcPluginName = jdbcPluginName;
+    this.dropDuringSnapshot = dropDuringSnapshot;
   }
 
   public String getDatabase() {
@@ -91,5 +97,9 @@ public class SqlServerConfig extends PluginConfig {
 
   public String getJDBCPluginId() {
     return String.format("%s.%s.%s", "sqlserversource", "jbdc", jdbcPluginName);
+  }
+
+  public boolean shouldDropDuringSnapshot() {
+    return dropDuringSnapshot == null ? false : dropDuringSnapshot;
   }
 }

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerEventReader.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerEventReader.java
@@ -109,7 +109,8 @@ public class SqlServerEventReader implements EventReader {
     try {
       // Create the engine with this configuration ...
       engine = EmbeddedEngine.create()
-        .notifying(new SqlServerRecordConsumer(context, emitter, databaseName, sourceTableMap))
+        .notifying(new SqlServerRecordConsumer(context, emitter, databaseName, sourceTableMap,
+                                               config.shouldDropDuringSnapshot()))
         .using(debeziumConf)
         .using(new NotifyingCompletionCallback(context))
         .build();

--- a/sqlserver-delta-plugins/widgets/sqlserver-cdcSource.json
+++ b/sqlserver-delta-plugins/widgets/sqlserver-cdcSource.json
@@ -60,6 +60,22 @@
           "widget-attributes": {
             "default": "UTC"
           }
+        },
+        {
+          "name": "dropDuringSnapshot",
+          "label": "Drop Tables During Snapshot",
+          "widget-type": "toggle",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
Added an option to filter out the drop database and drop table
events during the snapshot phase. Also fixed the integration tests
for sqlserver to expect a create database event.