### PR TITLE
[CDAP-16743] Fixed the issue that sql server plugin failed to replicate changes if initial table is empty.

### DIFF
--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConstantOffsetBackingStore.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConstantOffsetBackingStore.java
@@ -34,7 +34,6 @@ public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStor
   private static final Gson GSON = new Gson();
   private static final String KEY = "{\"schema\":null,\"payload\":[\"delta\",{\"server\":\"dummy\"}]}";
   static final String SNAPSHOT_COMPLETED = "snapshot_completed";
-  static final String SNAPSHOT_TABLES = "snapshot_tables";
 
   @Override
   public void configure(WorkerConfig config) {
@@ -45,7 +44,6 @@ public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStor
     String commitStr = originalConfig.get(SourceInfo.COMMIT_LSN_KEY);
     String snapshot = originalConfig.get(SourceInfo.SNAPSHOT_KEY);
     String snapshotCompleted = originalConfig.get(SNAPSHOT_COMPLETED);
-    String snapshotTables = originalConfig.get(SNAPSHOT_TABLES);
 
     Map<String, Object> offset = new HashMap<>();
     if (!changeStr.isEmpty()) {
@@ -59,9 +57,6 @@ public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStor
     }
     if (!snapshotCompleted.isEmpty()) {
       offset.put(SNAPSHOT_COMPLETED, Boolean.valueOf(snapshotCompleted));
-    }
-    if (!snapshotTables.isEmpty()) {
-      offset.put(SNAPSHOT_TABLES, snapshotTables);
     }
 
     // if this is missing and we add an empty map, for some reason, the connector will still consider there is some

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConstantOffsetBackingStore.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConstantOffsetBackingStore.java
@@ -27,8 +27,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * The offset store class for sql server. Sql server expects the offset which contains:
- * 1. change_lsn, 2. commit_lsn, 3. snapshot, 4. snapshot_completed. 5. snapshot_tables
+ * The sql server constant offset store class is used by debezium only to retrieve the offset information.
+ * Debezium expects the offset which contains:
+ * 1. change_lsn, 2. commit_lsn, 3. snapshot, 4. snapshot_completed.
  */
 public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStore {
   private static final Gson GSON = new Gson();

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConstantOffsetBackingStore.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConstantOffsetBackingStore.java
@@ -20,7 +20,6 @@ import com.google.gson.Gson;
 import io.cdap.cdap.api.common.Bytes;
 import io.debezium.connector.sqlserver.SourceInfo;
 import org.apache.kafka.connect.runtime.WorkerConfig;
-import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.storage.MemoryOffsetBackingStore;
 
 import java.nio.ByteBuffer;
@@ -29,12 +28,13 @@ import java.util.Map;
 
 /**
  * The offset store class for sql server. Sql server expects the offset which contains:
- * 1. change_lsn, 2. commmit_lsn, 3. snapshot, 4. snapshot_completed.
+ * 1. change_lsn, 2. commit_lsn, 3. snapshot, 4. snapshot_completed. 5. snapshot_tables
  */
 public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStore {
-  private static final String SNAPSHOT_COMPLETED = "snapshot_completed";
   private static final Gson GSON = new Gson();
   private static final String KEY = "{\"schema\":null,\"payload\":[\"delta\",{\"server\":\"dummy\"}]}";
+  static final String SNAPSHOT_COMPLETED = "snapshot_completed";
+  static final String SNAPSHOT_TABLES = "snapshot_tables";
 
   @Override
   public void configure(WorkerConfig config) {
@@ -45,6 +45,7 @@ public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStor
     String commitStr = originalConfig.get(SourceInfo.COMMIT_LSN_KEY);
     String snapshot = originalConfig.get(SourceInfo.SNAPSHOT_KEY);
     String snapshotCompleted = originalConfig.get(SNAPSHOT_COMPLETED);
+    String snapshotTables = originalConfig.get(SNAPSHOT_TABLES);
 
     Map<String, Object> offset = new HashMap<>();
     if (!changeStr.isEmpty()) {
@@ -59,6 +60,9 @@ public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStor
     if (!snapshotCompleted.isEmpty()) {
       offset.put(SNAPSHOT_COMPLETED, Boolean.valueOf(snapshotCompleted));
     }
+    if (!snapshotTables.isEmpty()) {
+      offset.put(SNAPSHOT_TABLES, snapshotTables);
+    }
 
     // if this is missing and we add an empty map, for some reason, the connector will still consider there is some
     // value about the offset, and thus skip reading some values
@@ -68,42 +72,5 @@ public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStor
     byte[] offsetBytes = Bytes.toBytes(GSON.toJson(offset));
 
     data.put(ByteBuffer.wrap(Bytes.toBytes(KEY)), ByteBuffer.wrap(offsetBytes));
-  }
-
-  static Map<String, String> deserializeOffsets(Map<String, String> offsets) {
-    Map<String, String> offsetConfig = new HashMap<>();
-    String changeLsn = offsets.getOrDefault(SourceInfo.CHANGE_LSN_KEY, null);
-    String commitLsn = offsets.getOrDefault(SourceInfo.COMMIT_LSN_KEY, null);
-    String snapshot = offsets.getOrDefault(SourceInfo.SNAPSHOT_KEY, null);
-    String snapshotCompleted = offsets.getOrDefault(SNAPSHOT_COMPLETED, null);
-    // this is prevent NPE since the configuration does not allow putting null value,
-    // also WorkerConfig.get() will throw Exception if a configuration is not found, so have to put some value in it
-    offsetConfig.put(SourceInfo.CHANGE_LSN_KEY, changeLsn == null ? "" : changeLsn);
-    offsetConfig.put(SourceInfo.COMMIT_LSN_KEY, commitLsn == null ? "" : commitLsn);
-    offsetConfig.put(SourceInfo.SNAPSHOT_KEY, snapshot == null ? "" : snapshot);
-    offsetConfig.put(SNAPSHOT_COMPLETED, snapshotCompleted == null ? "" : snapshotCompleted);
-    return offsetConfig;
-  }
-
-  static Map<String, String> serializeOffsets(SourceRecord sourceRecord) {
-    Map<String, ?> sourceOffset = sourceRecord.sourceOffset();
-    String changLsn = (String) sourceOffset.get(SourceInfo.CHANGE_LSN_KEY);
-    String commitLsn = (String) sourceOffset.get(SourceInfo.COMMIT_LSN_KEY);
-    Boolean snapshot = (Boolean) sourceOffset.get(SourceInfo.SNAPSHOT_KEY);
-    Boolean snapshotCompleted = (Boolean) sourceOffset.get(SNAPSHOT_COMPLETED);
-    Map<String, String> deltaOffset = new HashMap<>(4);
-    if (changLsn != null) {
-      deltaOffset.put(SourceInfo.CHANGE_LSN_KEY, changLsn);
-    }
-    if (commitLsn != null) {
-      deltaOffset.put(SourceInfo.COMMIT_LSN_KEY, commitLsn);
-    }
-    if (snapshot != null) {
-      deltaOffset.put(SourceInfo.SNAPSHOT_KEY, String.valueOf(snapshot));
-    }
-    if (snapshotCompleted != null) {
-      deltaOffset.put(SNAPSHOT_COMPLETED, String.valueOf(snapshotCompleted));
-    }
-    return deltaOffset;
   }
 }

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
@@ -51,7 +51,7 @@ public class SqlServerOffset {
   }
 
   void setSnapshotTables(Set<String> snapshotTables) {
-   this.snapshotTables = new HashSet<>(snapshotTables);
+    this.snapshotTables = new HashSet<>(snapshotTables);
   }
 
   void addSnapshotTable(String table) {

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
@@ -20,15 +20,19 @@ import io.debezium.connector.sqlserver.SourceInfo;
 import io.debezium.util.Strings;
 import org.apache.kafka.connect.source.SourceRecord;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Record offset information for SqlServer.
  */
 public class SqlServerOffset {
+  static final String DELIMITER = ",";
   static final String SNAPSHOT_TABLES = "snapshot_tables";
 
   private final Map<String, String> state;
@@ -39,10 +43,6 @@ public class SqlServerOffset {
 
   public SqlServerOffset(Map<String, String> state) {
     this.state = new ConcurrentHashMap<>(state);
-  }
-
-  public Map<String, String> get() {
-    return state;
   }
 
   Map<String, String> generateCdapOffsets(SourceRecord sourceRecord) {
@@ -71,6 +71,16 @@ public class SqlServerOffset {
     }
 
     return deltaOffset;
+  }
+
+  Set<String> getSnapshotTables() {
+    String snapshotTables = state.get(SqlServerOffset.SNAPSHOT_TABLES);
+    return Strings.isNullOrEmpty(snapshotTables) ? new HashSet<>() :
+      new HashSet<>(Arrays.asList(snapshotTables.split(DELIMITER)));
+  }
+
+  void setSnapshotTables(Set<String> snapshotTableSet) {
+    state.put(SqlServerOffset.SNAPSHOT_TABLES, String.join(DELIMITER, snapshotTableSet));
   }
 
   @Override

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.sqlserver;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Record offset information for SqlServer.
+ */
+public class SqlServerOffset {
+  private final Map<String, String> state;
+
+  public SqlServerOffset() {
+    this.state = new ConcurrentHashMap<>();
+  }
+
+  public SqlServerOffset(Map<String, String> state) {
+    this.state = new ConcurrentHashMap<>(state);
+  }
+
+  public Map<String, String> get() {
+    return state;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SqlServerOffset that = (SqlServerOffset) o;
+    return Objects.equals(state, that.state);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(state);
+  }
+}

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
@@ -142,7 +142,7 @@ public class SqlServerRecordConsumer implements Consumer<SourceRecord> {
                                  .setSnapshot(isSnapshot);
 
     Schema schema = value.getSchema();
-    // send the ddl event only if it see the table at the first time
+    // send the ddl events only if we see the table at the first time in both cache and offset
     // Note: the delta app itself have prevented adding CREATE_TABLE operation into DDL blacklist for all the tables.
     if (!trackingTables.contains(trackingTable) && !snapshotTableSet.contains(sourceTableId)) {
       StructuredRecord key = Records.convert((Struct) sourceRecord.key());


### PR DESCRIPTION
Background: we have noticed for sql server plugin. If our initial table is empty. After we start inserting record into the table, delta replicator will fail and complain about not dataset found. The reason for this is that we will only emit ddl events when the first record we read is a snapshot record and in-memory cache has not seen that before. 

To fix this in a better way, this PR will add additional information "snapshot_tables" into offset. Every time, we will emit ddl events if we had never seen this table in cache and offset before. It has to be in offset currently, because delta replicator will rely on if the target has finished the ddl events and persist the information rather than the source. 

Testing: Tested with following cases. 1. initial table is empty during snapshotting. 2. initial table is not empty during snapshotting.  3.stop and rerun the worker. In each case, offset was able to pick up correctly and replicate to target as expected (no duplicates or truncates.)