### PR TITLE
[CDAP-17402] Upgrade debizum version to 1.3.1.Final

### DIFF
--- a/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/DBSchemaHistory.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/DBSchemaHistory.java
@@ -78,6 +78,11 @@ public class DBSchemaHistory extends AbstractDatabaseHistory {
     }
   }
 
+  @Override
+  public boolean storageExists() {
+    return true;
+  }
+
   // TODO: cache history, should only have to read once
   private List<HistoryRecord> getHistory() {
     List<HistoryRecord> history = new ArrayList<>();

--- a/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/Records.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/Records.java
@@ -304,7 +304,8 @@ public class Records {
         for (Field field : fields) {
           cdapFields.add(Schema.Field.of(field.name(), convert(field.schema())));
         }
-        converted = Schema.recordOf(schema.name(), cdapFields);
+
+        converted = Schema.recordOf(schema.name() == null ? "dummy.schema.name" : schema.name(), cdapFields);
         break;
       default:
         // should never happen, all values are listed above

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -5,34 +5,38 @@
  */
 package io.debezium.connector.mysql;
 
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.Random;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
-import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.heartbeat.Heartbeat;
-import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
-import io.debezium.relational.Tables.TableFilter;
-import io.debezium.relational.ddl.DdlParser;
 import io.debezium.relational.history.DatabaseHistory;
 import io.debezium.relational.history.KafkaDatabaseHistory;
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.Importance;
-import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigDef.Width;
-
-import java.math.BigDecimal;
-import java.time.Duration;
-import java.util.Random;
 
 /**
  * The configuration properties.
  */
 public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MySqlConnectorConfig.class);
+  protected static final String DATABASE_INCLUDE_LIST_ALREADY_SPECIFIED_ERROR_MSG = "\"database.include.list\" or \"database.whitelist\" is already specified";
 
   /**
    * The set of predefined BigIntUnsignedHandlingMode options or aliases.
@@ -52,11 +56,12 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     private final String value;
 
-    BigIntUnsignedHandlingMode(String value) {
+    private BigIntUnsignedHandlingMode(String value) {
       this.value = value;
     }
 
-    @Override public String getValue() {
+    @Override
+    public String getValue() {
       return value;
     }
 
@@ -108,7 +113,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
   /**
    * The set of predefined SnapshotMode options or aliases.
    */
-  public enum SnapshotMode implements EnumeratedValue {
+  public static enum SnapshotMode implements EnumeratedValue {
 
     /**
      * Perform a snapshot when it is needed.
@@ -128,11 +133,10 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     SCHEMA_ONLY("schema_only", false),
 
     /**
-     * Perform a snapshot of only the database schemas (without data) and then begin reading the binlog at the current
-     * binlog position. This can be used for recovery only if the connector has existing offsets and the
-     * database.history.kafka.topic does not exist (deleted).
-     * This recovery option should be used with care as it assumes there have been no schema changes since the connector
-     * last stopped, otherwise some events during the gap may be processed with an incorrect schema and corrupted.
+     * Perform a snapshot of only the database schemas (without data) and then begin reading the binlog at the current binlog position.
+     * This can be used for recovery only if the connector has existing offsets and the database.history.kafka.topic does not exist (deleted).
+     * This recovery option should be used with care as it assumes there have been no schema changes since the connector last stopped,
+     * otherwise some events during the gap may be processed with an incorrect schema and corrupted.
      */
     SCHEMA_ONLY_RECOVERY("schema_only_recovery", false),
 
@@ -150,7 +154,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     private final String value;
     private final boolean includeData;
 
-    SnapshotMode(String value, boolean includeData) {
+    private SnapshotMode(String value, boolean includeData) {
       this.value = value;
       this.includeData = includeData;
     }
@@ -203,10 +207,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
   }
 
-  /**
-   * Class for snapshot new tables.
-   */
-  public enum SnapshotNewTables implements EnumeratedValue {
+  public static enum SnapshotNewTables implements EnumeratedValue {
     /**
      * Do not snapshot new tables
      */
@@ -219,7 +220,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     private final String value;
 
-    SnapshotNewTables(String value) {
+    private SnapshotNewTables(String value) {
       this.value = value;
     }
 
@@ -266,7 +267,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
   /**
    * The set of predefined Snapshot Locking Mode options.
    */
-  public enum SnapshotLockingMode implements EnumeratedValue {
+  public static enum SnapshotLockingMode implements EnumeratedValue {
 
     /**
      * This mode will block all writes for the entire duration of the snapshot.
@@ -276,30 +277,57 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     EXTENDED("extended"),
 
     /**
-     * The connector holds the global read lock for just the initial portion of the snapshot while the connector reads
-     * the database schemas and other metadata. The remaining work in a snapshot involves selecting all rows from each
-     * table, and this can be done in a consistent fashion using the REPEATABLE READ transaction even when the global
-     * read lock is no longer held and while other MySQL clients are updating the database.
+     * The connector holds the global read lock for just the initial portion of the snapshot while the connector reads the database
+     * schemas and other metadata. The remaining work in a snapshot involves selecting all rows from each table, and this can be done
+     * in a consistent fashion using the REPEATABLE READ transaction even when the global read lock is no longer held and while other
+     * MySQL clients are updating the database.
      *
      * Replaces deprecated configuration option snapshot.locking.minimal with a value of true.
      */
     MINIMAL("minimal"),
 
     /**
-     * This mode will avoid using ANY table locks during the snapshot process.  This mode can only be used with
-     * SnapShotMode set to schema_only or schema_only_recovery.
+     * The connector holds a (Percona-specific) backup lock for just the initial portion of the snapshot while the connector
+     * reads the database schemas and other metadata. This lock will only block DDL and DML on non-transactional tables
+     * (MyISAM etc.). The remaining work in a snapshot involves selecting all rows from each table, and this can be done in a
+     * consistent fashion using the REPEATABLE READ transaction even when the global read lock is no longer held and while other
+     * MySQL clients are updating the database.
+     */
+    MINIMAL_PERCONA("minimal_percona"),
+
+    /**
+     * This mode will avoid using ANY table locks during the snapshot process.  This mode can only be used with SnapShotMode
+     * set to schema_only or schema_only_recovery.
      */
     NONE("none");
 
     private final String value;
 
-    SnapshotLockingMode(String value) {
+    private SnapshotLockingMode(String value) {
       this.value = value;
     }
 
     @Override
     public String getValue() {
       return value;
+    }
+
+    public boolean usesMinimalLocking() {
+      return value.equals(MINIMAL.value) || value.equals(MINIMAL_PERCONA.value);
+    }
+
+    /**
+     * Determine which flavour of MySQL locking to use.
+     *
+     * @return the correct SQL to obtain a global lock for the current mode
+     */
+    public String getLockStatement() {
+      if (value.equals(MINIMAL_PERCONA.value)) {
+        return "LOCK TABLES FOR BACKUP";
+      }
+      else {
+        return "FLUSH TABLES WITH READ LOCK";
+      }
     }
 
     /**
@@ -340,7 +368,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
   /**
    * The set of predefined SecureConnectionMode options or aliases.
    */
-  public enum SecureConnectionMode implements EnumeratedValue {
+  public static enum SecureConnectionMode implements EnumeratedValue {
     /**
      * Establish an unencrypted connection.
      */
@@ -369,7 +397,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     private final String value;
 
-    SecureConnectionMode(String value) {
+    private SecureConnectionMode(String value) {
       this.value = value;
     }
 
@@ -416,7 +444,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
   /**
    * The set of predefined Gtid New Channel Position options.
    */
-  public enum GtidNewChannelPosition implements EnumeratedValue {
+  public static enum GtidNewChannelPosition implements EnumeratedValue {
 
     /**
      * This mode will start reading new gtid channel from mysql servers last_executed position
@@ -425,14 +453,13 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     /**
      * This mode will start reading new gtid channel from earliest available position in server.
-     * This is needed when during active-passive failover the new gtid channel becomes active and receiving writes.
-     * #DBZ-923
+     * This is needed when during active-passive failover the new gtid channel becomes active and receiving writes. #DBZ-923
      */
     EARLIEST("earliest");
 
     private final String value;
 
-    GtidNewChannelPosition(String value) {
+    private GtidNewChannelPosition(String value) {
       this.value = value;
     }
 
@@ -477,137 +504,15 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
   }
 
   /**
-   * The set of predefined modes for dealing with failures during binlog event processing.
-   */
-  public enum EventProcessingFailureHandlingMode implements EnumeratedValue {
-
-    /**
-     * Problematic events will be skipped.
-     */
-    IGNORE("ignore"),
-
-    /**
-     * Problematic event and their binlog position will be logged and the events will be skipped.
-     */
-    WARN("warn"),
-
-    /**
-     * An exception indicating the problematic events and their binlog position is raised, causing the connector to be
-     * stopped.
-     */
-    FAIL("fail");
-
-    private final String value;
-
-    EventProcessingFailureHandlingMode(String value) {
-      this.value = value;
-    }
-
-    @Override
-    public String getValue() {
-      return value;
-    }
-
-    /**
-     * Determine if the supplied value is one of the predefined options.
-     *
-     * @param value the configuration property value; may not be null
-     * @return the matching option, or null if no match is found
-     */
-    public static EventProcessingFailureHandlingMode parse(String value) {
-      if (value == null) {
-        return null;
-      }
-
-      value = value.trim();
-
-      for (EventProcessingFailureHandlingMode option : EventProcessingFailureHandlingMode.values()) {
-        if (option.getValue().equalsIgnoreCase(value)) {
-          return option;
-        }
-      }
-
-      return null;
-    }
-  }
-
-  /**
-   * Class for DdlParsingMode
-   */
-  public enum DdlParsingMode implements EnumeratedValue {
-
-    LEGACY("legacy") {
-      @Override
-      public DdlParser getNewParserInstance(JdbcValueConverters valueConverters, TableFilter tableFilter) {
-        return new MySqlDdlParser(false, (MySqlValueConverters) valueConverters);
-      }
-    },
-    ANTLR("antlr") {
-      @Override
-      public DdlParser getNewParserInstance(JdbcValueConverters valueConverters, TableFilter tableFilter) {
-        return new MySqlAntlrDdlParser((MySqlValueConverters) valueConverters, tableFilter);
-      }
-    };
-
-    private final String value;
-
-    DdlParsingMode(String value) {
-      this.value = value;
-    }
-
-    @Override
-    public String getValue() {
-      return value;
-    }
-
-    public abstract DdlParser getNewParserInstance(JdbcValueConverters valueConverters, TableFilter tableFilter);
-
-    /**
-     * Determine if the supplied value is one of the predefined options.
-     *
-     * @param value the configuration property value; may not be null
-     * @return the matching option, or null if no match is found
-     */
-    public static DdlParsingMode parse(String value) {
-      if (value == null) {
-        return null;
-      }
-      value = value.trim();
-      for (DdlParsingMode option : DdlParsingMode.values()) {
-        if (option.getValue().equalsIgnoreCase(value)) {
-          return option;
-        }
-      }
-      return null;
-    }
-
-    /**
-     * Determine if the supplied value is one of the predefined options.
-     *
-     * @param value the configuration property value; may not be null
-     * @param defaultValue the default value; may be null
-     * @return the matching option, or null if no match is found and the non-null default is invalid
-     */
-    public static DdlParsingMode parse(String value, String defaultValue) {
-      DdlParsingMode mode = parse(value);
-      if (mode == null && defaultValue != null) {
-        mode = parse(defaultValue);
-      }
-      return mode;
-    }
-  }
-
-  /**
    * {@link Integer#MIN_VALUE Minimum value} used for fetch size hint.
    * See <a href="https://issues.jboss.org/browse/DBZ-94">DBZ-94</a> for details.
    */
   protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = Integer.MIN_VALUE;
 
   private static final String DATABASE_WHITELIST_NAME = "database.whitelist";
+  private static final String DATABASE_INCLUDE_LIST_NAME = "database.include.list";
   private static final String DATABASE_BLACKLIST_NAME = "database.blacklist";
-  private static final String TABLE_WHITELIST_NAME = "table.whitelist";
-  private static final String TABLE_BLACKLIST_NAME = "table.blacklist";
-  private static final String TABLE_IGNORE_BUILTIN_NAME = "table.ignore.builtin";
+  private static final String DATABASE_EXCLUDE_LIST_NAME = "database.exclude.list";
 
   /**
    * Default size of the binlog buffer used for examining transactions and
@@ -654,12 +559,13 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withType(Type.STRING)
     .withWidth(Width.LONG)
     .withImportance(Importance.LOW)
-    .withDescription("A semicolon separated list of SQL statements to be executed when a JDBC connection " +
-                       "(not binlog reading connection) to the database is established. "
-                       + "Note that the connector may establish JDBC connections at its own discretion, so this " +
-                       "should typically be used for configuration of session parameters only,"
-                       + "but not for executing DML statements. Use doubled semicolon (';;') to use a semicolon " +
-                       "as a character and not as a delimiter.");
+    .withDescription(
+      "A semicolon separated list of SQL statements to be executed when a JDBC connection (not binlog reading connection) to the database is established. "
+        + "Note that the connector may establish JDBC connections at its own discretion, so this should typically be used for configuration of session parameters only,"
+        + "but not for executing DML statements. Use doubled semicolon (';;') to use a semicolon as a character and not as a delimiter.");
+
+  public static final Field SERVER_NAME = RelationalDatabaseConnectorConfig.SERVER_NAME
+    .withValidation(CommonConnectorConfig::validateServerNameIsDifferentFromHistoryTopicName);
 
   public static final Field SERVER_ID = Field.create("database.server.id")
     .withDisplayName("Cluster ID")
@@ -691,59 +597,46 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.MEDIUM)
     .withDescription("Whether to use an encrypted connection to MySQL. Options include"
                        + "'disabled' (the default) to use an unencrypted connection; "
-                       + "'preferred' to establish a secure (encrypted) connection if the server supports " +
-                       "secure connections, "
+                       + "'preferred' to establish a secure (encrypted) connection if the server supports secure connections, "
                        + "but fall back to an unencrypted connection otherwise; "
                        + "'required' to use a secure (encrypted) connection, and fail if one cannot be established; "
-                       + "'verify_ca' like 'required' but additionally verify the server TLS certificate against the " +
-                       "configured Certificate Authority "
+                       + "'verify_ca' like 'required' but additionally verify the server TLS certificate against the configured Certificate Authority "
                        + "(CA) certificates, or fail if no valid matching CA certificates are found; or"
-                       + "'verify_identity' like 'verify_ca' but additionally verify that the server certificate " +
-                       "matches the host to which the connection is attempted.");
+                       + "'verify_identity' like 'verify_ca' but additionally verify that the server certificate matches the host to which the connection is attempted.");
 
   public static final Field SSL_KEYSTORE = Field.create("database.ssl.keystore")
     .withDisplayName("SSL Keystore")
     .withType(Type.STRING)
     .withWidth(Width.LONG)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Location of the Java keystore file containing an application process's own " +
-                       "certificate and private key.");
+    .withDescription("Location of the Java keystore file containing an application process's own certificate and private key.");
 
   public static final Field SSL_KEYSTORE_PASSWORD = Field.create("database.ssl.keystore.password")
     .withDisplayName("SSL Keystore Password")
     .withType(Type.PASSWORD)
     .withWidth(Width.MEDIUM)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Password to access the private key from the keystore file specified by 'ssl.keystore' " +
-                       "configuration property or the 'javax.net.ssl.keyStore' system or JVM property. "
-                       + "This password is used to unlock the keystore file (store password), and to decrypt the " +
-                       "private key stored in the keystore (key password).");
+    .withDescription(
+      "Password to access the private key from the keystore file specified by 'ssl.keystore' configuration property or the 'javax.net.ssl.keyStore' system or JVM property. "
+        + "This password is used to unlock the keystore file (store password), and to decrypt the private key stored in the keystore (key password).");
 
   public static final Field SSL_TRUSTSTORE = Field.create("database.ssl.truststore")
     .withDisplayName("SSL Truststore")
     .withType(Type.STRING)
     .withWidth(Width.LONG)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Location of the Java truststore file containing the collection of CA certificates trusted by " +
-                       "this application process (trust store).");
+    .withDescription("Location of the Java truststore file containing the collection of CA certificates trusted by this application process (trust store).");
 
   public static final Field SSL_TRUSTSTORE_PASSWORD = Field.create("database.ssl.truststore.password")
     .withDisplayName("SSL Truststore Password")
     .withType(Type.PASSWORD)
     .withWidth(Width.MEDIUM)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Password to unlock the keystore file (store password) specified by 'ssl.trustore' " +
-                       "configuration property or the 'javax.net.ssl.trustStore' system or JVM property.");
+    .withDescription(
+      "Password to unlock the keystore file (store password) specified by 'ssl.trustore' configuration property or the 'javax.net.ssl.trustStore' system or JVM property.");
 
-  public static final Field TABLES_IGNORE_BUILTIN = Field.create(TABLE_IGNORE_BUILTIN_NAME)
-    .withDisplayName("Ignore system databases")
-    .withType(Type.BOOLEAN)
-    .withWidth(Width.SHORT)
-    .withImportance(Importance.LOW)
-    .withDefault(true)
-    .withValidation(Field::isBoolean)
-    .withDependents(DATABASE_WHITELIST_NAME)
-    .withDescription("Flag specifying whether built-in tables should be ignored.");
+  public static final Field TABLES_IGNORE_BUILTIN = RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN
+    .withDependents(DATABASE_INCLUDE_LIST_NAME);
 
   /**
    * ===================== This is a diff from the original file ===========================
@@ -759,76 +652,75 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
   /**
    * A comma-separated list of regular expressions that match database names to be monitored.
-   * May not be used with {@link #DATABASE_BLACKLIST}.
+   * Must not be used with {@link #DATABASE_BLACKLIST}.
    */
-  public static final Field DATABASE_WHITELIST = Field.create(DATABASE_WHITELIST_NAME)
-    .withDisplayName("Databases")
+  public static final Field DATABASE_INCLUDE_LIST = Field.create(DATABASE_INCLUDE_LIST_NAME)
+    .withDisplayName("Include Databases")
     .withType(Type.LIST)
     .withWidth(Width.LONG)
     .withImportance(Importance.HIGH)
-    .withDependents(TABLE_WHITELIST_NAME)
+    .withDependents(TABLE_INCLUDE_LIST_NAME)
     .withDescription("The databases for which changes are to be captured");
 
   /**
-   * A comma-separated list of regular expressions that match database names to be excluded from monitoring.
-   * May not be used with {@link #DATABASE_WHITELIST}.
+   * Old, backwards-compatible "whitelist" property.
    */
-  public static final Field DATABASE_BLACKLIST = Field.create(DATABASE_BLACKLIST_NAME)
+  @Deprecated
+  public static final Field DATABASE_WHITELIST = Field.create(DATABASE_WHITELIST_NAME)
+    .withDisplayName("Deprecated: Include Databases")
+    .withType(Type.LIST)
+    .withWidth(Width.LONG)
+    .withImportance(Importance.LOW)
+    .withInvisibleRecommender()
+    .withDependents(TABLE_INCLUDE_LIST_NAME)
+    .withDescription("The databases for which changes are to be captured (deprecated, use \"" + DATABASE_INCLUDE_LIST.name() + "\" instead)");
+
+  /**
+   * A comma-separated list of regular expressions that match database names to be excluded from monitoring.
+   * Must not be used with {@link #DATABASE_INCLUDE_LIST}.
+   */
+  public static final Field DATABASE_EXCLUDE_LIST = Field.create(DATABASE_EXCLUDE_LIST_NAME)
     .withDisplayName("Exclude Databases")
     .withType(Type.STRING)
     .withWidth(Width.LONG)
     .withImportance(Importance.MEDIUM)
-    .withValidation(MySqlConnectorConfig::validateDatabaseBlacklist)
+    .withValidation(MySqlConnectorConfig::validateDatabaseExcludeList)
     .withInvisibleRecommender()
-    .withDescription("");
+    .withDescription("A comma-separated list of regular expressions that match database names to be excluded from monitoring");
 
   /**
-   * A comma-separated list of regular expressions that match the fully-qualified names of tables to be monitored.
-   * Fully-qualified names for tables are of the form {@code <databaseName>.<tableName>} or
-   * {@code <databaseName>.<schemaName>.<tableName>}. May not be used with {@link #TABLE_BLACKLIST}, and superseded by
-   * database inclusions/exclusions.
+   * Old, backwards-compatible "blacklist" property.
    */
-  public static final Field TABLE_WHITELIST = Field.create(TABLE_WHITELIST_NAME)
-    .withDisplayName("Tables")
-    .withType(Type.LIST)
-    .withWidth(Width.LONG)
-    .withImportance(Importance.HIGH)
-    .withValidation(Field::isListOfRegex)
-    .withDescription("The tables for which changes are to be captured");
-
-  /**
-   * A comma-separated list of regular expressions that match the fully-qualified names of tables to be excluded from
-   * monitoring. Fully-qualified names for tables are of the form {@code <databaseName>.<tableName>} or
-   * {@code <databaseName>.<schemaName>.<tableName>}. May not be used with {@link #TABLE_WHITELIST}.
-   */
-  public static final Field TABLE_BLACKLIST = Field.create(TABLE_BLACKLIST_NAME)
-    .withDisplayName("Exclude Tables")
+  @Deprecated
+  public static final Field DATABASE_BLACKLIST = Field.create(DATABASE_BLACKLIST_NAME)
+    .withDisplayName("Deprecated: Exclude Databases")
     .withType(Type.STRING)
     .withWidth(Width.LONG)
-    .withImportance(Importance.MEDIUM)
-    .withValidation(Field::isListOfRegex, MySqlConnectorConfig::validateTableBlacklist)
-    .withInvisibleRecommender();
+    .withImportance(Importance.LOW)
+    .withValidation(MySqlConnectorConfig::validateDatabaseExcludeList)
+    .withInvisibleRecommender()
+    .withDescription("A comma-separated list of regular expressions that match database names to be excluded from monitoring (deprecated, use \""
+                       + DATABASE_EXCLUDE_LIST.name() + "\" instead)");
 
   /**
    * A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog
    * position in the MySQL server. Only the GTID ranges that have sources matching one of these include patterns will
    * be used.
-   * May not be used with {@link #GTID_SOURCE_EXCLUDES}.
+   * Must not be used with {@link #GTID_SOURCE_EXCLUDES}.
    */
   public static final Field GTID_SOURCE_INCLUDES = Field.create("gtid.source.includes")
     .withDisplayName("Include GTID sources")
     .withType(Type.LIST)
     .withWidth(Width.LONG)
     .withImportance(Importance.HIGH)
-    .withDependents(TABLE_WHITELIST_NAME)
-    .withDescription("The source UUIDs used to include GTID ranges when determine the starting position in the MySQL " +
-                       "server's binlog.");
+    .withDependents(TABLE_INCLUDE_LIST_NAME)
+    .withDescription("The source UUIDs used to include GTID ranges when determine the starting position in the MySQL server's binlog.");
 
   /**
    * A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog
    * position in the MySQL server. Only the GTID ranges that have sources matching none of these exclude patterns will
    * be used.
-   * May not be used with {@link #GTID_SOURCE_INCLUDES}.
+   * Must not be used with {@link #GTID_SOURCE_INCLUDES}.
    */
   public static final Field GTID_SOURCE_EXCLUDES = Field.create("gtid.source.excludes")
     .withDisplayName("Exclude GTID sources")
@@ -837,8 +729,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.MEDIUM)
     .withValidation(MySqlConnectorConfig::validateGtidSetExcludes)
     .withInvisibleRecommender()
-    .withDescription("The source UUIDs used to exclude GTID ranges when determine the starting position in the MySQL " +
-                       "server's binlog.");
+    .withDescription("The source UUIDs used to exclude GTID ranges when determine the starting position in the MySQL server's binlog.");
 
   /**
    * If set to true, we will only produce DML events into Kafka for transactions that were written on MySQL servers
@@ -855,26 +746,24 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
     .withDefault(true)
-    .withDescription("If set to true, we will only produce DML events into Kafka for transactions that were " +
-                       "written on mysql servers with UUIDs matching the filters defined by the gtid.source.includes " +
-                       "or gtid.source.excludes configuration options, if they are specified.");
+    .withDescription(
+      "If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers with UUIDs matching the filters defined by the gtid.source.includes or gtid.source.excludes configuration options, if they are specified.");
 
   /**
    * If set to 'latest', connector when encountering new GTID channel after job restart will start reading it from the
-   * latest executed position (default). When set to 'earliest' the connector will start reading new GTID channels
-   * from the first available position. This is useful when in active-passive mysql setup during failover new GTID
-   * channel starts receiving writes, see DBZ-923.
+   * latest executed position (default). When set to 'earliest' the connector will start reading new GTID channels from the first available position.
+   * This is useful when in active-passive mysql setup during failover new GTID channel starts receiving writes, see DBZ-923.
    *
    * Defaults to latest.
    */
   public static final Field GTID_NEW_CHANNEL_POSITION = Field.create("gtid.new.channel.position")
     .withDisplayName("GTID start position")
-    .withEnum(GtidNewChannelPosition.class, GtidNewChannelPosition.LATEST)
+    .withEnum(GtidNewChannelPosition.class, GtidNewChannelPosition.EARLIEST)
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
-    .withDescription("If set to 'latest', when connector sees new GTID, it will start consuming gtid channel " +
-                       "from the server latest executed gtid position. If 'earliest' connector starts reading " +
-                       "channel from first available (not purged) gtid position on the server.");
+    .withValidation(MySqlConnectorConfig::validateGtidNewChannelPositionNotSet)
+    .withDescription(
+      "If set to 'latest', when connector sees new GTID, it will start consuming gtid channel from the server latest executed gtid position. If 'earliest' (the default) connector starts reading channel from first available (not purged) gtid position on the server.");
 
   public static final Field CONNECTION_TIMEOUT_MS = Field.create("connect.timeout.ms")
     .withDisplayName("Connection Timeout (ms)")
@@ -927,8 +816,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withValidation(Field::isNonNegativeInteger);
 
   /**
-   * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user
-   * interface, and in these situations using Kafka is the only way to go.
+   * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user interface,
+   * and in these situations using Kafka is the only way to go.
    */
   public static final Field DATABASE_HISTORY = Field.create("database.history")
     .withDisplayName("Database history class")
@@ -936,34 +825,20 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.LONG)
     .withImportance(Importance.LOW)
     .withInvisibleRecommender()
-    .withDescription("The name of the DatabaseHistory class that should be used to store and recover database " +
-                       "schema changes. The configuration properties for the history are prefixed with the '" +
-                       DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING + "' string.")
+    .withDescription("The name of the DatabaseHistory class that should be used to store and recover database schema changes. "
+                       + "The configuration properties for the history are prefixed with the '"
+                       + DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING + "' string.")
     .withDefault(KafkaDatabaseHistory.class.getName());
-
-  public static final Field INCLUDE_SCHEMA_CHANGES = Field.create("include.schema.changes")
-    .withDisplayName("Include database schema changes")
-    .withType(Type.BOOLEAN)
-    .withWidth(Width.SHORT)
-    .withImportance(Importance.MEDIUM)
-    .withDescription("Whether the connector should publish changes in the database schema to a Kafka topic with " +
-                       "the same name as the database server ID. Each schema change will be recorded using a " +
-                       "key that contains the database name and whose value includes the DDL statement(s)." +
-                       "The default is 'true'. This is independent of how the connector internally records database " +
-                       "history.")
-    .withDefault(true);
 
   public static final Field INCLUDE_SQL_QUERY = Field.create("include.query")
     .withDisplayName("Include original SQL query with in change events")
     .withType(Type.BOOLEAN)
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Whether the connector should include the original SQL query that generated the change event. " +
-                       "Note: This option requires MySQL be configured with the binlog_rows_query_log_events " +
-                       "option set to ON. Query will not be present for events generated from snapshot. " +
-                       "WARNING: Enabling this option may expose tables or fields explicitly blacklisted or masked " +
-                       "by including the original SQL statement in the change event. " +
-                       "For this reason the default value is 'false'.")
+    .withDescription("Whether the connector should include the original SQL query that generated the change event. "
+                       + "Note: This option requires MySQL be configured with the binlog_rows_query_log_events option set to ON. Query will not be present for events generated from snapshot. "
+                       + "WARNING: Enabling this option may expose tables or fields explicitly blacklisted or masked by including the original SQL statement in the change event. "
+                       + "For this reason the default value is 'false'.")
     .withDefault(false);
 
   public static final Field SNAPSHOT_MODE = Field.create("snapshot.mode")
@@ -971,55 +846,28 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withEnum(SnapshotMode.class, SnapshotMode.INITIAL)
     .withWidth(Width.SHORT)
     .withImportance(Importance.LOW)
-    .withDescription("The criteria for running a snapshot upon startup of the connector. " +
-                       "Options include: 'when_needed' to specify that the connector run a snapshot upon startup " +
-                       "whenever it deems it necessary; 'initial' (the default) to specify the connector can run " +
-                       "a snapshot only when no offsets are available for the logical server name; " +
-                       "'initial_only' same as 'initial' except the connector should stop after completing the " +
-                       "snapshot and before it would normally read the binlog; and 'never' to specify the " +
-                       "connector should never run a snapshot and that upon first startup the connector should " +
-                       "read from the beginning of the binlog. The 'never' mode should be used with care, and " +
-                       "only when the binlog is known to contain all history.");
-
-  /**
-   * @deprecated Replaced with SNAPSHOT_LOCKING_MODE
-   */
-  @Deprecated
-  public static final Field SNAPSHOT_MINIMAL_LOCKING = Field.create("snapshot.minimal.locks")
-    .withDisplayName("Use shortest database locking for snapshots")
-    .withType(Type.BOOLEAN)
-    .withWidth(Width.SHORT)
-    .withImportance(Importance.LOW)
-    .withDescription("NOTE: This option has been deprecated in favor of snapshot.locking.mode. \n"
-                       + "Controls how long the connector holds onto the global read lock while it is performing " +
-                       "a snapshot. The default is 'true', which means the connector holds the global read lock " +
-                       "(and thus prevents any updates) for just the initial portion of the snapshot "
-                       + "while the database schemas and other metadata are being read. The remaining work in a " +
-                       "snapshot involves selecting all rows from "
-                       + "each table, and this can be done using the snapshot process' REPEATABLE READ transaction " +
-                       "even when the lock is no longer held and "
-                       + "other operations are updating the database. However, in some cases it may be desirable " +
-                       "to block all writes for the entire duration "
-                       + "of the snapshot; in such cases set this property to 'false'.")
-    .withDefault(true);
+    .withDescription("The criteria for running a snapshot upon startup of the connector. "
+                       + "Options include: "
+                       + "'when_needed' to specify that the connector run a snapshot upon startup whenever it deems it necessary; "
+                       + "'schema_only' to only take a snapshot of the schema (table structures) but no actual data; "
+                       + "'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; "
+                       + "'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally read the binlog; and"
+                       + "'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the beginning of the binlog. "
+                       + "The 'never' mode should be used with care, and only when the binlog is known to contain all history.");
 
   public static final Field SNAPSHOT_LOCKING_MODE = Field.create("snapshot.locking.mode")
     .withDisplayName("Snapshot locking mode")
     .withEnum(SnapshotLockingMode.class, SnapshotLockingMode.MINIMAL)
     .withWidth(Width.SHORT)
     .withImportance(Importance.LOW)
-    .withDescription("Controls how long the connector holds onto the global read lock while it is performing a " +
-                       "snapshot. The default is 'minimal', which means the connector holds the global read lock " +
-                       "(and thus prevents any updates) for just the initial portion of the snapshot " +
-                       "while the database schemas and other metadata are being read. The remaining work in " +
-                       "a snapshot involves selecting all rows from each table, and this can be done using the " +
-                       "snapshot process' REPEATABLE READ transaction even when the lock is no longer held and " +
-                       "other operations are updating the database. However, in some cases it may be desirable " +
-                       "to block all writes for the entire duration of the snapshot; in such cases set this " +
-                       "property to 'extended'. Using a value of 'none' will prevent the connector from acquiring " +
-                       "any table locks during the snapshot process. This mode can only be used in combination with " +
-                       "snapshot.mode values of 'schema_only' or 'schema_only_recovery' and is only safe to use" +
-                       " if no schema changes are happening while the snapshot is taken.")
+    .withDescription("Controls how long the connector holds onto the global read lock while it is performing a snapshot. The default is 'minimal', "
+                       + "which means the connector holds the global read lock (and thus prevents any updates) for just the initial portion of the snapshot "
+                       + "while the database schemas and other metadata are being read. The remaining work in a snapshot involves selecting all rows from "
+                       + "each table, and this can be done using the snapshot process' REPEATABLE READ transaction even when the lock is no longer held and "
+                       + "other operations are updating the database. However, in some cases it may be desirable to block all writes for the entire duration "
+                       + "of the snapshot; in such cases set this property to 'extended'. Using a value of 'none' will prevent the connector from acquiring any "
+                       + "table locks during the snapshot process. This mode can only be used in combination with snapshot.mode values of 'schema_only' or "
+                       + "'schema_only_recovery' and is only safe to use if no schema changes are happening while the snapshot is taken.")
     .withValidation(MySqlConnectorConfig::validateSnapshotLockingMode);
 
   public static final Field SNAPSHOT_NEW_TABLES = Field.create("snapshot.new.tables")
@@ -1027,128 +875,53 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withEnum(SnapshotNewTables.class, SnapshotNewTables.OFF)
     .withWidth(Width.SHORT)
     .withImportance(Importance.LOW)
-    .withDescription("BETA FEATURE: On connector restart, the connector will check if there have been any new tables " +
-                       "added to the configuration, and snapshot them. There is presently only two options:" +
-                       "'off': Default behavior. Do not snapshot new tables." +
-                       "'parallel': The snapshot of the new tables will occur in parallel to the continued binlog " +
-                       "reading of the old tables. When the snapshot completes, an independent binlog reader will " +
-                       "begin reading the events for the new tables until it catches up to present time. At this " +
-                       "point, both old and new binlog readers will be momentarily halted and new binlog reader " +
-                       "will start that will read the binlog for all configured tables. The parallel binlog reader " +
-                       "will have a configured server id of 10000 + the primary binlog reader's server id.");
+    .withDescription("BETA FEATURE: On connector restart, the connector will check if there have been any new tables added to the configuration, "
+                       + "and snapshot them. There is presently only two options:"
+                       + "'off': Default behavior. Do not snapshot new tables."
+                       + "'parallel': The snapshot of the new tables will occur in parallel to the continued binlog reading of the old tables. When the snapshot "
+                       + "completes, an independent binlog reader will begin reading the events for the new tables until it catches up to present time. At this "
+                       + "point, both old and new binlog readers will be momentarily halted and new binlog reader will start that will read the binlog for all "
+                       + "configured tables. The parallel binlog reader will have a configured server id of 10000 + the primary binlog reader's server id.");
 
-  public static final Field TIME_PRECISION_MODE = Field.create("time.precision.mode")
-    .withDisplayName("Time Precision")
+  public static final Field TIME_PRECISION_MODE = RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE
     .withEnum(TemporalPrecisionMode.class, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS)
-    .withWidth(Width.SHORT)
-    .withImportance(Importance.MEDIUM)
-    .withDescription("Time, date, and timestamps can be represented with different kinds of precisions, including:" +
-                       "'adaptive_time_microseconds' (the default) like 'adaptive' mode, but TIME fields always " +
-                       "use microseconds precision; 'adaptive' (deprecated) bases the precision of time, date, " +
-                       "and timestamp values on the database column's precision; 'connect' always represents " +
-                       "time, date, and timestamp values using Kafka Connect's built-in representations for Time, " +
-                       "Date, and Timestamp, which uses millisecond precision regardless of the database " +
-                       "columns' precision.");
+    .withValidation(MySqlConnectorConfig::validateTimePrecisionMode)
+    .withDescription("Time, date and timestamps can be represented with different kinds of precisions, including:"
+                       + "'adaptive_time_microseconds': the precision of date and timestamp values is based the database column's precision; but time fields always use microseconds precision;"
+                       + "'connect': always represents time, date and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, "
+                       + "which uses millisecond precision regardless of the database columns' precision.");
 
   public static final Field BIGINT_UNSIGNED_HANDLING_MODE = Field.create("bigint.unsigned.handling.mode")
     .withDisplayName("BIGINT UNSIGNED Handling")
     .withEnum(BigIntUnsignedHandlingMode.class, BigIntUnsignedHandlingMode.LONG)
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Specify how BIGINT UNSIGNED columns should be represented in change events, including:" +
-                       "'precise' uses java.math.BigDecimal to represent values, which are encoded in the " +
-                       "change events using a binary representation and Kafka Connect's " +
-                       "'org.apache.kafka.connect.data.Decimal' type; 'long' (the default) represents values " +
-                       "using Java's 'long', which may not offer the precision but will be far easier to use " +
-                       "in consumers.");
+    .withDescription("Specify how BIGINT UNSIGNED columns should be represented in change events, including:"
+                       + "'precise' uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; "
+                       + "'long' (the default) represents values using Java's 'long', which may not offer the precision but will be far easier to use in consumers.");
 
-  public static final Field EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE =
-    Field.create("event.deserialization.failure.handling.mode")
+  public static final Field EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE = Field.create("event.deserialization.failure.handling.mode")
     .withDisplayName("Event deserialization failure handling")
     .withEnum(EventProcessingFailureHandlingMode.class, EventProcessingFailureHandlingMode.FAIL)
+    .withValidation(MySqlConnectorConfig::validateEventDeserializationFailureHandlingModeNotSet)
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Specify how failures during deserialization of binlog events (i.e. when encountering a " +
-                       "corrupted event) should be handled, including: 'fail' (the default) an exception indicating " +
-                       "the problematic event and its binlog position is raised, causing the connector to be " +
-                       "stopped; 'warn' the problematic event and its binlog position will be logged and the event" +
-                       " will be skipped; 'ignore' the problematic event will be skipped.");
+    .withDescription("Specify how failures during deserialization of binlog events (i.e. when encountering a corrupted event) should be handled, including:"
+                       + "'fail' (the default) an exception indicating the problematic event and its binlog position is raised, causing the connector to be stopped; "
+                       + "'warn' the problematic event and its binlog position will be logged and the event will be skipped;"
+                       + "'ignore' the problematic event will be skipped.");
 
   public static final Field INCONSISTENT_SCHEMA_HANDLING_MODE = Field.create("inconsistent.schema.handling.mode")
     .withDisplayName("Inconsistent schema failure handling")
     .withEnum(EventProcessingFailureHandlingMode.class, EventProcessingFailureHandlingMode.FAIL)
+    .withValidation(MySqlConnectorConfig::validateInconsistentSchemaHandlingModeNotIgnore)
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Specify how binlog events that belong to a table missing from internal schema representation " +
-                       "(i.e. internal representation is not consistent with database) should be handled, including:"
-                       + "'fail' (the default) an exception indicating the problematic event and its binlog position " +
-                       "is raised, causing the connector to be stopped; 'warn' the problematic event and its binlog " +
-                       "position will be logged and the event will be skipped; 'ignore' the problematic event " +
-                       "will be skipped.");
-
-  public static final Field SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE =
-    Field.create("snapshot.select.statement.overrides")
-    .withDisplayName("List of tables where the default select statement used during snapshotting should be overridden.")
-    .withType(Type.STRING)
-    .withWidth(Width.LONG)
-    .withImportance(Importance.MEDIUM)
-    .withDescription(" This property contains a comma-separated list of fully-qualified tables (DB_NAME.TABLE_NAME). " +
-                       "Select statements for the individual tables are specified in further configuration " +
-                       "properties, one for each table, identified by the id " +
-                       "'snapshot.select.statement.overrides.[DB_NAME].[TABLE_NAME]'. " +
-                       "The value of those properties is the select statement to use when retrieving data from " +
-                       "the specific table during snapshotting. " +
-                       "A possible use case for large append-only tables is setting a specific point where to " +
-                       "start (resume) snapshotting, in case a previous snapshotting was interrupted.");
-
-  public static final Field DDL_PARSER_MODE = Field.create("ddl.parser.mode")
-    .withDisplayName("DDL parser mode")
-    .withEnum(DdlParsingMode.class, DdlParsingMode.ANTLR)
-    .withWidth(Width.SHORT)
-    .withImportance(Importance.MEDIUM)
-    .withDescription("MySQL DDL statements can be parsed in different ways:" +
-                       "'legacy' parsing is creating a TokenStream and comparing token by token with an " +
-                       "expected values." +
-                       "The decisions are made by matched token values." +
-                       "'antlr' (the default) uses generated parser from MySQL grammar using ANTLR v4 tool" +
-                       " which use ALL(*) algorithm for parsing." +
-                       "This parser creates a parsing tree for DDL statement, then walks trough it and apply " +
-                       "changes by node types in parsed tree.");
-
-  /**
-   * Method that generates a Field for specifying that string columns whose names match a set of regular expressions
-   * should have their values truncated to be no longer than the specified number of characters.
-   *
-   * @param length the maximum length of the column's string values written in source records; must be positive
-   * @return the field; never null
-   */
-  public static final Field TRUNCATE_COLUMN(int length) {
-    if (length <= 0) {
-      throw new IllegalArgumentException("The truncation length must be positive");
-    }
-    return Field.create("column.truncate.to." + length + ".chars")
-      .withValidation(Field::isInteger)
-      .withDescription("A comma-separated list of regular expressions matching fully-qualified names of columns" +
-                         " that should be truncated to " + length + " characters.");
-  }
-
-  /**
-   * Method that generates a Field for specifying that string columns whose names match a set of regular expressions
-   * should have their values masked by the specified number of asterisk ('*') characters.
-   *
-   * @param length the number of asterisks that should appear in place of the column's string values written in source
-   *               records; must be positive
-   * @return the field; never null
-   */
-  public static final Field MASK_COLUMN(int length) {
-    if (length <= 0) {
-      throw new IllegalArgumentException("The mask length must be positive");
-    }
-    return Field.create("column.mask.with." + length + ".chars")
-      .withValidation(Field::isInteger)
-      .withDescription("A comma-separated list of regular expressions matching fully-qualified names of columns " +
-                         "that should be masked with " + length + " asterisk ('*') characters.");
-  }
+    .withDescription(
+      "Specify how binlog events that belong to a table missing from internal schema representation (i.e. internal representation is not consistent with database) should be handled, including:"
+        + "'fail' (the default) an exception indicating the problematic event and its binlog position is raised, causing the connector to be stopped; "
+        + "'warn' the problematic event and its binlog position will be logged and the event will be skipped;"
+        + "'skip' the problematic event will be skipped.");
 
   public static final Field ENABLE_TIME_ADJUSTER = Field.create("enable.time.adjuster")
     .withDisplayName("Enable Time Adjuster")
@@ -1156,29 +929,30 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withDefault(true)
     .withWidth(Width.SHORT)
     .withImportance(Importance.LOW)
-    .withDescription("MySQL allows user to insert year value as either 2-digit or 4-digit. In case of two digit " +
-                       "the value is automatically mapped into 1970 - 2069." +
-                       "false - delegates the implicit conversion to the database" +
-                       "true - (the default) Debezium makes the conversion");
+    .withDescription(
+      "MySQL allows user to insert year value as either 2-digit or 4-digit. In case of two digit the value is automatically mapped into 1970 - 2069." +
+        "false - delegates the implicit conversion to the database" +
+        "true - (the default) Debezium makes the conversion");
 
   /**
    * The set of {@link Field}s defined as part of this configuration.
    */
-  public static Field.Set ALL_FIELDS = Field.setOf(USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS, SERVER_ID,
-                                                   SERVER_ID_OFFSET,
-                                                   RelationalDatabaseConnectorConfig.SERVER_NAME,
+  public static Field.Set ALL_FIELDS = Field.setOf(USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS, SERVER_ID, SERVER_ID_OFFSET,
+                                                   SERVER_NAME,
                                                    CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS,
                                                    CommonConnectorConfig.MAX_QUEUE_SIZE,
                                                    CommonConnectorConfig.MAX_BATCH_SIZE,
                                                    CommonConnectorConfig.POLL_INTERVAL_MS,
                                                    BUFFER_SIZE_FOR_BINLOG_READER, Heartbeat.HEARTBEAT_INTERVAL,
-                                                   Heartbeat.HEARTBEAT_TOPICS_PREFIX, DATABASE_HISTORY,
-                                                   INCLUDE_SCHEMA_CHANGES, INCLUDE_SQL_QUERY,
-                                                   TABLE_WHITELIST, TABLE_BLACKLIST, TABLES_IGNORE_BUILTIN,
-                                                   DATABASE_WHITELIST, DATABASE_BLACKLIST,
-                                                   COLUMN_BLACKLIST,
-                                                   SNAPSHOT_MODE, SNAPSHOT_NEW_TABLES, SNAPSHOT_MINIMAL_LOCKING,
-                                                   SNAPSHOT_LOCKING_MODE,
+                                                   Heartbeat.HEARTBEAT_TOPICS_PREFIX, DATABASE_HISTORY, INCLUDE_SCHEMA_CHANGES, INCLUDE_SQL_QUERY,
+                                                   TABLE_WHITELIST, TABLE_INCLUDE_LIST, TABLE_BLACKLIST, TABLE_EXCLUDE_LIST, TABLES_IGNORE_BUILTIN,
+                                                   DATABASE_WHITELIST, DATABASE_INCLUDE_LIST, DATABASE_BLACKLIST, DATABASE_EXCLUDE_LIST,
+                                                   COLUMN_BLACKLIST, COLUMN_EXCLUDE_LIST, COLUMN_INCLUDE_LIST, MSG_KEY_COLUMNS,
+                                                   RelationalDatabaseConnectorConfig.MASK_COLUMN_WITH_HASH,
+                                                   RelationalDatabaseConnectorConfig.MASK_COLUMN,
+                                                   RelationalDatabaseConnectorConfig.TRUNCATE_COLUMN,
+                                                   SNAPSHOT_MODE, SNAPSHOT_NEW_TABLES, SNAPSHOT_LOCKING_MODE,
+                                                   RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
                                                    GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES,
                                                    GTID_SOURCE_FILTER_DML_EVENTS,
                                                    GTID_NEW_CHANNEL_POSITION,
@@ -1187,17 +961,20 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                    SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD, JDBC_DRIVER,
                                                    BIGINT_UNSIGNED_HANDLING_MODE,
                                                    EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE,
+                                                   CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE,
                                                    INCONSISTENT_SCHEMA_HANDLING_MODE,
                                                    CommonConnectorConfig.SNAPSHOT_DELAY_MS,
                                                    CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
-                                                   DDL_PARSER_MODE,
-                                                   CommonConnectorConfig.TOMBSTONES_ON_DELETE, ENABLE_TIME_ADJUSTER);
+                                                   CommonConnectorConfig.TOMBSTONES_ON_DELETE, ENABLE_TIME_ADJUSTER,
+                                                   CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION,
+                                                   CommonConnectorConfig.SKIPPED_OPERATIONS,
+                                                   BINARY_HANDLING_MODE);
 
   /**
    * The set of {@link Field}s that are included in the {@link #configDef() configuration definition}. This includes
-   * all fields defined in this class (though some are always invisible since they are not to be exposed to the user
-   * interface) plus several that are specific to the {@link KafkaDatabaseHistory} class, since history is always
-   * stored in Kafka when run via the user interface.
+   * all fields defined in this class (though some are always invisible since they are not to be exposed to the user interface)
+   * plus several that are specific to the {@link KafkaDatabaseHistory} class, since history is always stored in Kafka
+   * when run via the user interface.
    */
   protected static Field.Set EXPOSED_FIELDS = ALL_FIELDS.with(KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
                                                               KafkaDatabaseHistory.TOPIC,
@@ -1208,53 +985,33 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                               DatabaseHistory.DDL_FILTER);
 
   private final SnapshotLockingMode snapshotLockingMode;
-  private final DdlParsingMode ddlParsingMode;
   private final GtidNewChannelPosition gitIdNewChannelPosition;
   private final SnapshotNewTables snapshotNewTables;
+  private final TemporalPrecisionMode temporalPrecisionMode;
+  private final Duration connectionTimeout;
 
   public MySqlConnectorConfig(Configuration config) {
     super(
       config,
-      config.getString(RelationalDatabaseConnectorConfig.SERVER_NAME),
+      config.getString(SERVER_NAME),
       null, // TODO whitelist handling is still done locally here
-      null
-    );
+      null,
+      DEFAULT_SNAPSHOT_FETCH_SIZE);
 
-    // If deprecated snapshot.minimal.locking property is explicitly configured
-    if (config.hasKey(MySqlConnectorConfig.SNAPSHOT_MINIMAL_LOCKING.name())) {
-      // Coerce it into its replacement appropriate snapshot.locking.mode value
-      if (config.getBoolean(MySqlConnectorConfig.SNAPSHOT_MINIMAL_LOCKING)) {
-        this.snapshotLockingMode = SnapshotLockingMode.MINIMAL;
-      } else {
-        this.snapshotLockingMode = SnapshotLockingMode.EXTENDED;
-      }
-    } else {
-      // Otherwise use configured snapshot.locking.mode configuration.
-      this.snapshotLockingMode =
-        SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE),
-                                  SNAPSHOT_LOCKING_MODE.defaultValueAsString());
-    }
-
-    String ddlParsingModeStr = config.getString(MySqlConnectorConfig.DDL_PARSER_MODE);
-    this.ddlParsingMode = DdlParsingMode.parse(ddlParsingModeStr,
-                                               MySqlConnectorConfig.DDL_PARSER_MODE.defaultValueAsString());
+    this.temporalPrecisionMode = TemporalPrecisionMode.parse(config.getString(TIME_PRECISION_MODE));
+    this.snapshotLockingMode = SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE), SNAPSHOT_LOCKING_MODE.defaultValueAsString());
 
     String gitIdNewChannelPosition = config.getString(MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION);
-    this.gitIdNewChannelPosition =
-      GtidNewChannelPosition.parse(gitIdNewChannelPosition,
-                                   MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION.defaultValueAsString());
+    this.gitIdNewChannelPosition = GtidNewChannelPosition.parse(gitIdNewChannelPosition, MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION.defaultValueAsString());
 
     String snapshotNewTables = config.getString(MySqlConnectorConfig.SNAPSHOT_NEW_TABLES);
-    this.snapshotNewTables = SnapshotNewTables.parse(snapshotNewTables,
-                                                     MySqlConnectorConfig.SNAPSHOT_NEW_TABLES.defaultValueAsString());
+    this.snapshotNewTables = SnapshotNewTables.parse(snapshotNewTables, MySqlConnectorConfig.SNAPSHOT_NEW_TABLES.defaultValueAsString());
+
+    this.connectionTimeout = Duration.ofMillis(config.getLong(MySqlConnectorConfig.CONNECTION_TIMEOUT_MS));
   }
 
   public SnapshotLockingMode getSnapshotLockingMode() {
     return this.snapshotLockingMode;
-  }
-
-  public DdlParsingMode getDdlParsingMode() {
-    return ddlParsingMode;
   }
 
   public GtidNewChannelPosition gtidNewChannelPosition() {
@@ -1265,50 +1022,72 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     return snapshotNewTables;
   }
 
-  @Override
-  protected int defaultSnapshotFetchSize(Configuration config) {
-    return DEFAULT_SNAPSHOT_FETCH_SIZE;
-  }
-
   protected static ConfigDef configDef() {
     ConfigDef config = new ConfigDef();
-    Field.group(config, "MySQL", HOSTNAME, PORT, USER, PASSWORD, ON_CONNECT_STATEMENTS,
-                RelationalDatabaseConnectorConfig.SERVER_NAME, SERVER_ID, SERVER_ID_OFFSET,
-                SSL_MODE, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD, SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD, JDBC_DRIVER);
+    Field.group(config, "MySQL", HOSTNAME, PORT, USER, PASSWORD, ON_CONNECT_STATEMENTS, SERVER_NAME, SERVER_ID, SERVER_ID_OFFSET,
+                SSL_MODE, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD, SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD, JDBC_DRIVER, CommonConnectorConfig.SKIPPED_OPERATIONS);
     Field.group(config, "History Storage", KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
                 KafkaDatabaseHistory.TOPIC, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
                 KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, DATABASE_HISTORY,
                 DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, DatabaseHistory.DDL_FILTER,
                 DatabaseHistory.STORE_ONLY_MONITORED_TABLES_DDL);
     Field.group(config, "Events", INCLUDE_SCHEMA_CHANGES, INCLUDE_SQL_QUERY, TABLES_IGNORE_BUILTIN,
-                DATABASE_WHITELIST, TABLE_WHITELIST, COLUMN_BLACKLIST, TABLE_BLACKLIST, DATABASE_BLACKLIST,
-                GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS, GTID_NEW_CHANNEL_POSITION,
-                BUFFER_SIZE_FOR_BINLOG_READER, Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX,
-                EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE, INCONSISTENT_SCHEMA_HANDLING_MODE,
-                CommonConnectorConfig.TOMBSTONES_ON_DELETE);
-    Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS,
-                CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.MAX_BATCH_SIZE,
-                CommonConnectorConfig.POLL_INTERVAL_MS, SNAPSHOT_MODE, SNAPSHOT_LOCKING_MODE, SNAPSHOT_NEW_TABLES,
-                SNAPSHOT_MINIMAL_LOCKING, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE, BIGINT_UNSIGNED_HANDLING_MODE,
-                SNAPSHOT_DELAY_MS, SNAPSHOT_FETCH_SIZE, DDL_PARSER_MODE, ENABLE_TIME_ADJUSTER);
+                DATABASE_WHITELIST, DATABASE_INCLUDE_LIST, TABLE_WHITELIST, TABLE_INCLUDE_LIST,
+                COLUMN_BLACKLIST, COLUMN_EXCLUDE_LIST, COLUMN_INCLUDE_LIST, TABLE_BLACKLIST, TABLE_EXCLUDE_LIST,
+                DATABASE_BLACKLIST, DATABASE_EXCLUDE_LIST, MSG_KEY_COLUMNS,
+                RelationalDatabaseConnectorConfig.MASK_COLUMN_WITH_HASH,
+                RelationalDatabaseConnectorConfig.MASK_COLUMN,
+                RelationalDatabaseConnectorConfig.TRUNCATE_COLUMN,
+                RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
+                GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS, GTID_NEW_CHANNEL_POSITION, BUFFER_SIZE_FOR_BINLOG_READER,
+                Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX, EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE,
+                CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE, INCONSISTENT_SCHEMA_HANDLING_MODE,
+                CommonConnectorConfig.TOMBSTONES_ON_DELETE, CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION);
+    Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS, CommonConnectorConfig.MAX_QUEUE_SIZE,
+                CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
+                SNAPSHOT_MODE, SNAPSHOT_LOCKING_MODE, SNAPSHOT_NEW_TABLES, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
+                BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_DELAY_MS, SNAPSHOT_FETCH_SIZE, ENABLE_TIME_ADJUSTER, BINARY_HANDLING_MODE);
     return config;
   }
 
-  private static int validateDatabaseBlacklist(Configuration config, Field field, ValidationOutput problems) {
-    String whitelist = config.getString(DATABASE_WHITELIST);
-    String blacklist = config.getString(DATABASE_BLACKLIST);
-    if (whitelist != null && blacklist != null) {
-      problems.accept(DATABASE_BLACKLIST, blacklist, "Whitelist is already specified");
-      return 1;
+  private static int validateGtidNewChannelPositionNotSet(Configuration config, Field field, ValidationOutput problems) {
+    if (config.getString(GTID_NEW_CHANNEL_POSITION.name()) != null) {
+      LOGGER.warn("Configuration option '{}' is deprecated and scheduled for removal", GTID_NEW_CHANNEL_POSITION.name());
     }
     return 0;
   }
 
-  private static int validateTableBlacklist(Configuration config, Field field, ValidationOutput problems) {
-    String whitelist = config.getString(TABLE_WHITELIST);
-    String blacklist = config.getString(TABLE_BLACKLIST);
-    if (whitelist != null && blacklist != null) {
-      problems.accept(TABLE_BLACKLIST, blacklist, "Whitelist is already specified");
+  private static int validateEventDeserializationFailureHandlingModeNotSet(Configuration config, Field field, ValidationOutput problems) {
+    final String modeName = config.asMap().get(EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE.name());
+    if (modeName != null) {
+      LOGGER.warn("Configuration option '{}' is renamed to '{}'", EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE.name(),
+                  EVENT_PROCESSING_FAILURE_HANDLING_MODE.name());
+      if (EventProcessingFailureHandlingMode.OBSOLETE_NAME_FOR_SKIP_FAILURE_HANDLING.equals(modeName)) {
+        LOGGER.warn("Value '{}' of configuration option '{}' is deprecated and should be replaced with '{}'",
+                    EventProcessingFailureHandlingMode.OBSOLETE_NAME_FOR_SKIP_FAILURE_HANDLING,
+                    EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE.name(),
+                    EventProcessingFailureHandlingMode.SKIP.getValue());
+      }
+    }
+    return 0;
+  }
+
+  private static int validateInconsistentSchemaHandlingModeNotIgnore(Configuration config, Field field, ValidationOutput problems) {
+    final String modeName = config.getString(INCONSISTENT_SCHEMA_HANDLING_MODE);
+    if (EventProcessingFailureHandlingMode.OBSOLETE_NAME_FOR_SKIP_FAILURE_HANDLING.equals(modeName)) {
+      LOGGER.warn("Value '{}' of configuration option '{}' is deprecated and should be replaced with '{}'",
+                  EventProcessingFailureHandlingMode.OBSOLETE_NAME_FOR_SKIP_FAILURE_HANDLING,
+                  INCONSISTENT_SCHEMA_HANDLING_MODE.name(),
+                  EventProcessingFailureHandlingMode.SKIP.getValue());
+    }
+    return 0;
+  }
+
+  private static int validateDatabaseExcludeList(Configuration config, Field field, ValidationOutput problems) {
+    String includeList = config.getFallbackStringProperty(DATABASE_INCLUDE_LIST, DATABASE_WHITELIST);
+    String excludeList = config.getFallbackStringProperty(DATABASE_EXCLUDE_LIST, DATABASE_BLACKLIST);
+    if (includeList != null && excludeList != null) {
+      problems.accept(DATABASE_EXCLUDE_LIST, excludeList, DATABASE_INCLUDE_LIST_ALREADY_SPECIFIED_ERROR_MSG);
       return 1;
     }
     return 0;
@@ -1338,44 +1117,34 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
    */
   private static int validateSnapshotLockingMode(Configuration config, Field field, ValidationOutput problems) {
     // Determine which configurations are explicitly defined
-    final boolean isMinimalLockingExplicitlyDefined = config.hasKey(SNAPSHOT_MINIMAL_LOCKING.name());
-    final boolean isSnapshotModeExplicitlyDefined = config.hasKey(SNAPSHOT_LOCKING_MODE.name());
-
-    // If both configuration options are explicitly defined, we'll throw a validation error.
-    if (isMinimalLockingExplicitlyDefined && isSnapshotModeExplicitlyDefined) {
-      // Then display a validation error.
-      problems.accept(SNAPSHOT_MINIMAL_LOCKING,
-                      config.getBoolean(SNAPSHOT_MINIMAL_LOCKING),
-                      "Deprecated configuration " + SNAPSHOT_MINIMAL_LOCKING.name() +
-                        " in conflict. Cannot use both " + SNAPSHOT_MINIMAL_LOCKING.name() + " and " +
-                        SNAPSHOT_LOCKING_MODE.name() + " configuration options.");
-      return 1;
-    }
-
-    // Determine what value to use for SnapshotLockingMode
-    final SnapshotLockingMode lockingModeValue;
-
-    // if minimalLocking is defined
-    if (isMinimalLockingExplicitlyDefined) {
-      // Grab the configured minimal locks configuration option
-      final boolean minimalLocksEnabled = config.getBoolean(MySqlConnectorConfig.SNAPSHOT_MINIMAL_LOCKING);
-
-      // Coerce minimal locking => snapshot mode.
-      if (minimalLocksEnabled) {
-        lockingModeValue = SnapshotLockingMode.MINIMAL;
-      } else {
-        lockingModeValue = SnapshotLockingMode.EXTENDED;
+    if (config.hasKey(SNAPSHOT_LOCKING_MODE.name())) {
+      final SnapshotLockingMode lockingModeValue = SnapshotLockingMode.parse(
+        config.getString(MySqlConnectorConfig.SNAPSHOT_LOCKING_MODE));
+      // Sanity check, validate the configured value is a valid option.
+      if (lockingModeValue == null) {
+        problems.accept(SNAPSHOT_LOCKING_MODE, lockingModeValue, "Must be a valid snapshot.locking.mode value");
+        return 1;
       }
-    } else {
-      // Otherwise use SnapshotLockingMode
-      // Grab explicitly configured value
-      lockingModeValue = SnapshotLockingMode.parse(config.getString(MySqlConnectorConfig.SNAPSHOT_LOCKING_MODE));
     }
 
-    // Sanity check, validate the configured value is a valid option.
-    if (lockingModeValue == null) {
-      problems.accept(SNAPSHOT_LOCKING_MODE, lockingModeValue, "Must be a valid snapshot.locking.mode value");
-      return 1;
+    // Everything checks out ok.
+    return 0;
+  }
+
+  /**
+   * Validate the time.precision.mode configuration.
+   *
+   * If {@code adaptive} is specified, this option has the potential to cause overflow which is why the
+   * option was deprecated and no longer supported for this connector.
+   */
+  private static int validateTimePrecisionMode(Configuration config, Field field, ValidationOutput problems) {
+    if (config.hasKey(TIME_PRECISION_MODE.name())) {
+      final String timePrecisionMode = config.getString(TIME_PRECISION_MODE.name());
+      if (TemporalPrecisionMode.ADAPTIVE.getValue().equals(timePrecisionMode)) {
+        // this is a problem
+        problems.accept(TIME_PRECISION_MODE, timePrecisionMode, "The 'adaptive' time.precision.mode is no longer supported");
+        return 1;
+      }
     }
 
     // Everything checks out ok.
@@ -1386,5 +1155,34 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     int lowestServerId = 5400;
     int highestServerId = 6400;
     return lowestServerId + new Random().nextInt(highestServerId - lowestServerId);
+  }
+
+  @Override
+  protected SourceInfoStructMaker<? extends AbstractSourceInfo> getSourceInfoStructMaker(Version version) {
+    switch (version) {
+      case V1:
+        return new LegacyV1MySqlSourceInfoStructMaker(Module.name(), Module.version(), this);
+      default:
+        return new MySqlSourceInfoStructMaker(Module.name(), Module.version(), this);
+    }
+  }
+
+  @Override
+  public String getContextName() {
+    return Module.contextName();
+  }
+
+  @Override
+  public String getConnectorName() {
+    return Module.name();
+  }
+
+  @Override
+  public TemporalPrecisionMode getTemporalPrecisionMode() {
+    return temporalPrecisionMode;
+  }
+
+  public Duration getConnectionTimeout() {
+    return connectionTimeout;
   }
 }

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -5,17 +5,6 @@
  */
 package io.debezium.connector.mysql;
 
-import java.math.BigDecimal;
-import java.time.Duration;
-import java.util.Random;
-
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.Importance;
-import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigDef.Width;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
@@ -29,6 +18,16 @@ import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.history.DatabaseHistory;
 import io.debezium.relational.history.KafkaDatabaseHistory;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.Random;
 
 /**
  * The configuration properties.
@@ -36,7 +35,8 @@ import io.debezium.relational.history.KafkaDatabaseHistory;
 public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MySqlConnectorConfig.class);
-  protected static final String DATABASE_INCLUDE_LIST_ALREADY_SPECIFIED_ERROR_MSG = "\"database.include.list\" or \"database.whitelist\" is already specified";
+  protected static final String DATABASE_INCLUDE_LIST_ALREADY_SPECIFIED_ERROR_MSG
+    = "\"database.include.list\" or \"database.whitelist\" is already specified";
 
   /**
    * The set of predefined BigIntUnsignedHandlingMode options or aliases.
@@ -56,7 +56,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     private final String value;
 
-    private BigIntUnsignedHandlingMode(String value) {
+    BigIntUnsignedHandlingMode(String value) {
       this.value = value;
     }
 
@@ -113,7 +113,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
   /**
    * The set of predefined SnapshotMode options or aliases.
    */
-  public static enum SnapshotMode implements EnumeratedValue {
+  public enum SnapshotMode implements EnumeratedValue {
 
     /**
      * Perform a snapshot when it is needed.
@@ -133,10 +133,11 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     SCHEMA_ONLY("schema_only", false),
 
     /**
-     * Perform a snapshot of only the database schemas (without data) and then begin reading the binlog at the current binlog position.
-     * This can be used for recovery only if the connector has existing offsets and the database.history.kafka.topic does not exist (deleted).
-     * This recovery option should be used with care as it assumes there have been no schema changes since the connector last stopped,
-     * otherwise some events during the gap may be processed with an incorrect schema and corrupted.
+     * Perform a snapshot of only the database schemas (without data) and then begin reading the binlog at the current
+     * binlog position. This can be used for recovery only if the connector has existing offsets and the
+     * database.history.kafka.topic does not exist (deleted). This recovery option should be used with care as it
+     * assumes there have been no schema changes since the connector last stopped, otherwise some events during the
+     * gap may be processed with an incorrect schema and corrupted.
      */
     SCHEMA_ONLY_RECOVERY("schema_only_recovery", false),
 
@@ -154,7 +155,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     private final String value;
     private final boolean includeData;
 
-    private SnapshotMode(String value, boolean includeData) {
+    SnapshotMode(String value, boolean includeData) {
       this.value = value;
       this.includeData = includeData;
     }
@@ -207,7 +208,10 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
   }
 
-  public static enum SnapshotNewTables implements EnumeratedValue {
+  /**
+   *
+   */
+  public enum SnapshotNewTables implements EnumeratedValue {
     /**
      * Do not snapshot new tables
      */
@@ -220,7 +224,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     private final String value;
 
-    private SnapshotNewTables(String value) {
+    SnapshotNewTables(String value) {
       this.value = value;
     }
 
@@ -267,7 +271,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
   /**
    * The set of predefined Snapshot Locking Mode options.
    */
-  public static enum SnapshotLockingMode implements EnumeratedValue {
+  public enum SnapshotLockingMode implements EnumeratedValue {
 
     /**
      * This mode will block all writes for the entire duration of the snapshot.
@@ -277,33 +281,33 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     EXTENDED("extended"),
 
     /**
-     * The connector holds the global read lock for just the initial portion of the snapshot while the connector reads the database
-     * schemas and other metadata. The remaining work in a snapshot involves selecting all rows from each table, and this can be done
-     * in a consistent fashion using the REPEATABLE READ transaction even when the global read lock is no longer held and while other
-     * MySQL clients are updating the database.
+     * The connector holds the global read lock for just the initial portion of the snapshot while the connector reads
+     * the database schemas and other metadata. The remaining work in a snapshot involves selecting all rows from each
+     * table, and this can be done in a consistent fashion using the REPEATABLE READ transaction even when the global
+     * read lock is no longer held and while other MySQL clients are updating the database.
      *
      * Replaces deprecated configuration option snapshot.locking.minimal with a value of true.
      */
     MINIMAL("minimal"),
 
     /**
-     * The connector holds a (Percona-specific) backup lock for just the initial portion of the snapshot while the connector
-     * reads the database schemas and other metadata. This lock will only block DDL and DML on non-transactional tables
-     * (MyISAM etc.). The remaining work in a snapshot involves selecting all rows from each table, and this can be done in a
-     * consistent fashion using the REPEATABLE READ transaction even when the global read lock is no longer held and while other
-     * MySQL clients are updating the database.
+     * The connector holds a (Percona-specific) backup lock for just the initial portion of the snapshot while the
+     * connector reads the database schemas and other metadata. This lock will only block DDL and DML on
+     * non-transactional tables (MyISAM etc.). The remaining work in a snapshot involves selecting all rows from each
+     * table, and this can be done in a consistent fashion using the REPEATABLE READ transaction even when the global
+     * read lock is no longer held and while other MySQL clients are updating the database.
      */
     MINIMAL_PERCONA("minimal_percona"),
 
     /**
-     * This mode will avoid using ANY table locks during the snapshot process.  This mode can only be used with SnapShotMode
-     * set to schema_only or schema_only_recovery.
+     * This mode will avoid using ANY table locks during the snapshot process.  This mode can only be used with
+     * SnapShotMode set to schema_only or schema_only_recovery.
      */
     NONE("none");
 
     private final String value;
 
-    private SnapshotLockingMode(String value) {
+    SnapshotLockingMode(String value) {
       this.value = value;
     }
 
@@ -324,8 +328,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     public String getLockStatement() {
       if (value.equals(MINIMAL_PERCONA.value)) {
         return "LOCK TABLES FOR BACKUP";
-      }
-      else {
+      } else {
         return "FLUSH TABLES WITH READ LOCK";
       }
     }
@@ -368,7 +371,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
   /**
    * The set of predefined SecureConnectionMode options or aliases.
    */
-  public static enum SecureConnectionMode implements EnumeratedValue {
+  public enum SecureConnectionMode implements EnumeratedValue {
     /**
      * Establish an unencrypted connection.
      */
@@ -397,7 +400,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     private final String value;
 
-    private SecureConnectionMode(String value) {
+    SecureConnectionMode(String value) {
       this.value = value;
     }
 
@@ -444,7 +447,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
   /**
    * The set of predefined Gtid New Channel Position options.
    */
-  public static enum GtidNewChannelPosition implements EnumeratedValue {
+  public enum GtidNewChannelPosition implements EnumeratedValue {
 
     /**
      * This mode will start reading new gtid channel from mysql servers last_executed position
@@ -453,13 +456,14 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     /**
      * This mode will start reading new gtid channel from earliest available position in server.
-     * This is needed when during active-passive failover the new gtid channel becomes active and receiving writes. #DBZ-923
+     * This is needed when during active-passive failover the new gtid channel becomes active and receiving writes.
+     * #DBZ-923
      */
     EARLIEST("earliest");
 
     private final String value;
 
-    private GtidNewChannelPosition(String value) {
+    GtidNewChannelPosition(String value) {
       this.value = value;
     }
 
@@ -560,9 +564,12 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.LONG)
     .withImportance(Importance.LOW)
     .withDescription(
-      "A semicolon separated list of SQL statements to be executed when a JDBC connection (not binlog reading connection) to the database is established. "
-        + "Note that the connector may establish JDBC connections at its own discretion, so this should typically be used for configuration of session parameters only,"
-        + "but not for executing DML statements. Use doubled semicolon (';;') to use a semicolon as a character and not as a delimiter.");
+      "A semicolon separated list of SQL statements to be executed when a JDBC connection (not binlog reading " +
+        "connection) to the database is established. "
+        + "Note that the connector may establish JDBC connections at its own discretion, so this should typically be " +
+        "used for configuration of session parameters only,"
+        + "but not for executing DML statements. Use doubled semicolon (';;') to use a semicolon as a character and " +
+        "not as a delimiter.");
 
   public static final Field SERVER_NAME = RelationalDatabaseConnectorConfig.SERVER_NAME
     .withValidation(CommonConnectorConfig::validateServerNameIsDifferentFromHistoryTopicName);
@@ -597,19 +604,22 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.MEDIUM)
     .withDescription("Whether to use an encrypted connection to MySQL. Options include"
                        + "'disabled' (the default) to use an unencrypted connection; "
-                       + "'preferred' to establish a secure (encrypted) connection if the server supports secure connections, "
-                       + "but fall back to an unencrypted connection otherwise; "
+                       + "'preferred' to establish a secure (encrypted) connection if the server supports secure "
+                       + "connections, but fall back to an unencrypted connection otherwise; "
                        + "'required' to use a secure (encrypted) connection, and fail if one cannot be established; "
-                       + "'verify_ca' like 'required' but additionally verify the server TLS certificate against the configured Certificate Authority "
+                       + "'verify_ca' like 'required' but additionally verify the server TLS certificate against the "
+                       + "configured Certificate Authority "
                        + "(CA) certificates, or fail if no valid matching CA certificates are found; or"
-                       + "'verify_identity' like 'verify_ca' but additionally verify that the server certificate matches the host to which the connection is attempted.");
+                       + "'verify_identity' like 'verify_ca' but additionally verify that the server certificate "
+                       + "matches the host to which the connection is attempted.");
 
   public static final Field SSL_KEYSTORE = Field.create("database.ssl.keystore")
     .withDisplayName("SSL Keystore")
     .withType(Type.STRING)
     .withWidth(Width.LONG)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Location of the Java keystore file containing an application process's own certificate and private key.");
+    .withDescription("Location of the Java keystore file containing an application process's own certificate and " +
+                       "private key.");
 
   public static final Field SSL_KEYSTORE_PASSWORD = Field.create("database.ssl.keystore.password")
     .withDisplayName("SSL Keystore Password")
@@ -617,15 +627,17 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.MEDIUM)
     .withImportance(Importance.MEDIUM)
     .withDescription(
-      "Password to access the private key from the keystore file specified by 'ssl.keystore' configuration property or the 'javax.net.ssl.keyStore' system or JVM property. "
-        + "This password is used to unlock the keystore file (store password), and to decrypt the private key stored in the keystore (key password).");
+      "Password to access the private key from the keystore file specified by 'ssl.keystore' configuration property " +
+        "or the 'javax.net.ssl.keyStore' system or JVM property. This password is used to unlock the keystore file " +
+        "(store password), and to decrypt the private key stored in the keystore (key password).");
 
   public static final Field SSL_TRUSTSTORE = Field.create("database.ssl.truststore")
     .withDisplayName("SSL Truststore")
     .withType(Type.STRING)
     .withWidth(Width.LONG)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Location of the Java truststore file containing the collection of CA certificates trusted by this application process (trust store).");
+    .withDescription("Location of the Java truststore file containing the collection of CA certificates trusted by " +
+                       "this application process (trust store).");
 
   public static final Field SSL_TRUSTSTORE_PASSWORD = Field.create("database.ssl.truststore.password")
     .withDisplayName("SSL Truststore Password")
@@ -633,7 +645,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.MEDIUM)
     .withImportance(Importance.MEDIUM)
     .withDescription(
-      "Password to unlock the keystore file (store password) specified by 'ssl.trustore' configuration property or the 'javax.net.ssl.trustStore' system or JVM property.");
+      "Password to unlock the keystore file (store password) specified by 'ssl.trustore' configuration property or " +
+        "the 'javax.net.ssl.trustStore' system or JVM property.");
 
   public static final Field TABLES_IGNORE_BUILTIN = RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN
     .withDependents(DATABASE_INCLUDE_LIST_NAME);
@@ -673,7 +686,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.LOW)
     .withInvisibleRecommender()
     .withDependents(TABLE_INCLUDE_LIST_NAME)
-    .withDescription("The databases for which changes are to be captured (deprecated, use \"" + DATABASE_INCLUDE_LIST.name() + "\" instead)");
+    .withDescription("The databases for which changes are to be captured (deprecated, use \""
+                       + DATABASE_INCLUDE_LIST.name() + "\" instead)");
 
   /**
    * A comma-separated list of regular expressions that match database names to be excluded from monitoring.
@@ -686,7 +700,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.MEDIUM)
     .withValidation(MySqlConnectorConfig::validateDatabaseExcludeList)
     .withInvisibleRecommender()
-    .withDescription("A comma-separated list of regular expressions that match database names to be excluded from monitoring");
+    .withDescription("A comma-separated list of regular expressions that match database names to be excluded from " +
+                       "monitoring");
 
   /**
    * Old, backwards-compatible "blacklist" property.
@@ -699,7 +714,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.LOW)
     .withValidation(MySqlConnectorConfig::validateDatabaseExcludeList)
     .withInvisibleRecommender()
-    .withDescription("A comma-separated list of regular expressions that match database names to be excluded from monitoring (deprecated, use \""
+    .withDescription("A comma-separated list of regular expressions that match database names to be excluded from " +
+                       "monitoring (deprecated, use \""
                        + DATABASE_EXCLUDE_LIST.name() + "\" instead)");
 
   /**
@@ -714,7 +730,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.LONG)
     .withImportance(Importance.HIGH)
     .withDependents(TABLE_INCLUDE_LIST_NAME)
-    .withDescription("The source UUIDs used to include GTID ranges when determine the starting position in the MySQL server's binlog.");
+    .withDescription("The source UUIDs used to include GTID ranges when determine the starting position in the MySQL " +
+                       "server's binlog.");
 
   /**
    * A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog
@@ -729,7 +746,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.MEDIUM)
     .withValidation(MySqlConnectorConfig::validateGtidSetExcludes)
     .withInvisibleRecommender()
-    .withDescription("The source UUIDs used to exclude GTID ranges when determine the starting position in the MySQL server's binlog.");
+    .withDescription("The source UUIDs used to exclude GTID ranges when determine the starting position in the MySQL " +
+                       "server's binlog.");
 
   /**
    * If set to true, we will only produce DML events into Kafka for transactions that were written on MySQL servers
@@ -747,12 +765,15 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.MEDIUM)
     .withDefault(true)
     .withDescription(
-      "If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers with UUIDs matching the filters defined by the gtid.source.includes or gtid.source.excludes configuration options, if they are specified.");
+      "If set to true, we will only produce DML events into Kafka for transactions that were written on mysql " +
+        "servers with UUIDs matching the filters defined by the gtid.source.includes or gtid.source.excludes " +
+        "configuration options, if they are specified.");
 
   /**
-   * If set to 'latest', connector when encountering new GTID channel after job restart will start reading it from the
-   * latest executed position (default). When set to 'earliest' the connector will start reading new GTID channels from the first available position.
-   * This is useful when in active-passive mysql setup during failover new GTID channel starts receiving writes, see DBZ-923.
+   * If set to 'latest', connector when encountering new GTID channel after job restart will start reading it from
+   * the latest executed position (default). When set to 'earliest' the connector will start reading new GTID channels
+   * from the first available position. This is useful when in active-passive mysql setup during failover new GTID
+   * channel starts receiving writes, see DBZ-923.
    *
    * Defaults to latest.
    */
@@ -763,7 +784,9 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.MEDIUM)
     .withValidation(MySqlConnectorConfig::validateGtidNewChannelPositionNotSet)
     .withDescription(
-      "If set to 'latest', when connector sees new GTID, it will start consuming gtid channel from the server latest executed gtid position. If 'earliest' (the default) connector starts reading channel from first available (not purged) gtid position on the server.");
+      "If set to 'latest', when connector sees new GTID, it will start consuming gtid channel from the server latest " +
+        "executed gtid position. If 'earliest' (the default) connector starts reading channel from first available " +
+        "(not purged) gtid position on the server.");
 
   public static final Field CONNECTION_TIMEOUT_MS = Field.create("connect.timeout.ms")
     .withDisplayName("Connection Timeout (ms)")
@@ -816,8 +839,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withValidation(Field::isNonNegativeInteger);
 
   /**
-   * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user interface,
-   * and in these situations using Kafka is the only way to go.
+   * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user
+   * interface, and in these situations using Kafka is the only way to go.
    */
   public static final Field DATABASE_HISTORY = Field.create("database.history")
     .withDisplayName("Database history class")
@@ -825,7 +848,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.LONG)
     .withImportance(Importance.LOW)
     .withInvisibleRecommender()
-    .withDescription("The name of the DatabaseHistory class that should be used to store and recover database schema changes. "
+    .withDescription("The name of the DatabaseHistory class that should be used to store and recover database schema " +
+                       "changes. "
                        + "The configuration properties for the history are prefixed with the '"
                        + DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING + "' string.")
     .withDefault(KafkaDatabaseHistory.class.getName());
@@ -836,8 +860,10 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
     .withDescription("Whether the connector should include the original SQL query that generated the change event. "
-                       + "Note: This option requires MySQL be configured with the binlog_rows_query_log_events option set to ON. Query will not be present for events generated from snapshot. "
-                       + "WARNING: Enabling this option may expose tables or fields explicitly blacklisted or masked by including the original SQL statement in the change event. "
+                       + "Note: This option requires MySQL be configured with the binlog_rows_query_log_events " +
+                       "option set to ON. Query will not be present for events generated from snapshot. "
+                       + "WARNING: Enabling this option may expose tables or fields explicitly blacklisted or masked " +
+                       "by including the original SQL statement in the change event. "
                        + "For this reason the default value is 'false'.")
     .withDefault(false);
 
@@ -848,26 +874,39 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withImportance(Importance.LOW)
     .withDescription("The criteria for running a snapshot upon startup of the connector. "
                        + "Options include: "
-                       + "'when_needed' to specify that the connector run a snapshot upon startup whenever it deems it necessary; "
+                       + "'when_needed' to specify that the connector run a snapshot upon startup whenever it " +
+                       "deems it necessary; "
                        + "'schema_only' to only take a snapshot of the schema (table structures) but no actual data; "
-                       + "'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; "
-                       + "'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally read the binlog; and"
-                       + "'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the beginning of the binlog. "
-                       + "The 'never' mode should be used with care, and only when the binlog is known to contain all history.");
+                       + "'initial' (the default) to specify the connector can run a snapshot only when no offsets" +
+                       " are available for the logical server name; "
+                       + "'initial_only' same as 'initial' except the connector should stop after completing the " +
+                       "snapshot and before it would normally read the binlog; and"
+                       + "'never' to specify the connector should never run a snapshot and that upon first startup" +
+                       " the connector should read from the beginning of the binlog. "
+                       + "The 'never' mode should be used with care, and only when the binlog is known to contain" +
+                       " all history.");
 
   public static final Field SNAPSHOT_LOCKING_MODE = Field.create("snapshot.locking.mode")
     .withDisplayName("Snapshot locking mode")
     .withEnum(SnapshotLockingMode.class, SnapshotLockingMode.MINIMAL)
     .withWidth(Width.SHORT)
     .withImportance(Importance.LOW)
-    .withDescription("Controls how long the connector holds onto the global read lock while it is performing a snapshot. The default is 'minimal', "
-                       + "which means the connector holds the global read lock (and thus prevents any updates) for just the initial portion of the snapshot "
-                       + "while the database schemas and other metadata are being read. The remaining work in a snapshot involves selecting all rows from "
-                       + "each table, and this can be done using the snapshot process' REPEATABLE READ transaction even when the lock is no longer held and "
-                       + "other operations are updating the database. However, in some cases it may be desirable to block all writes for the entire duration "
-                       + "of the snapshot; in such cases set this property to 'extended'. Using a value of 'none' will prevent the connector from acquiring any "
-                       + "table locks during the snapshot process. This mode can only be used in combination with snapshot.mode values of 'schema_only' or "
-                       + "'schema_only_recovery' and is only safe to use if no schema changes are happening while the snapshot is taken.")
+    .withDescription("Controls how long the connector holds onto the global read lock while it is performing a " +
+                       "snapshot. The default is 'minimal', "
+                       + "which means the connector holds the global read lock (and thus prevents any updates) for " +
+                       "just the initial portion of the snapshot "
+                       + "while the database schemas and other metadata are being read. The remaining work in a " +
+                       "snapshot involves selecting all rows from "
+                       + "each table, and this can be done using the snapshot process' REPEATABLE READ transaction " +
+                       "even when the lock is no longer held and "
+                       + "other operations are updating the database. However, in some cases it may be desirable " +
+                       "to block all writes for the entire duration "
+                       + "of the snapshot; in such cases set this property to 'extended'. Using a value of 'none'" +
+                       " will prevent the connector from acquiring any "
+                       + "table locks during the snapshot process. This mode can only be used in combination with" +
+                       " snapshot.mode values of 'schema_only' or "
+                       + "'schema_only_recovery' and is only safe to use if no schema changes are happening while " +
+                       "the snapshot is taken.")
     .withValidation(MySqlConnectorConfig::validateSnapshotLockingMode);
 
   public static final Field SNAPSHOT_NEW_TABLES = Field.create("snapshot.new.tables")
@@ -875,20 +914,27 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withEnum(SnapshotNewTables.class, SnapshotNewTables.OFF)
     .withWidth(Width.SHORT)
     .withImportance(Importance.LOW)
-    .withDescription("BETA FEATURE: On connector restart, the connector will check if there have been any new tables added to the configuration, "
+    .withDescription("BETA FEATURE: On connector restart, the connector will check if there have been any new tables" +
+                       " added to the configuration, "
                        + "and snapshot them. There is presently only two options:"
                        + "'off': Default behavior. Do not snapshot new tables."
-                       + "'parallel': The snapshot of the new tables will occur in parallel to the continued binlog reading of the old tables. When the snapshot "
-                       + "completes, an independent binlog reader will begin reading the events for the new tables until it catches up to present time. At this "
-                       + "point, both old and new binlog readers will be momentarily halted and new binlog reader will start that will read the binlog for all "
-                       + "configured tables. The parallel binlog reader will have a configured server id of 10000 + the primary binlog reader's server id.");
+                       + "'parallel': The snapshot of the new tables will occur in parallel to the continued binlog" +
+                       " reading of the old tables. When the snapshot "
+                       + "completes, an independent binlog reader will begin reading the events for the new tables" +
+                       " until it catches up to present time. At this "
+                       + "point, both old and new binlog readers will be momentarily halted and new binlog reader" +
+                       " will start that will read the binlog for all "
+                       + "configured tables. The parallel binlog reader will have a configured server id of " +
+                       "10000 + the primary binlog reader's server id.");
 
   public static final Field TIME_PRECISION_MODE = RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE
     .withEnum(TemporalPrecisionMode.class, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS)
     .withValidation(MySqlConnectorConfig::validateTimePrecisionMode)
     .withDescription("Time, date and timestamps can be represented with different kinds of precisions, including:"
-                       + "'adaptive_time_microseconds': the precision of date and timestamp values is based the database column's precision; but time fields always use microseconds precision;"
-                       + "'connect': always represents time, date and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, "
+                       + "'adaptive_time_microseconds': the precision of date and timestamp values is based the " +
+                       "database column's precision; but time fields always use microseconds precision;"
+                       + "'connect': always represents time, date and timestamp values using Kafka Connect's " +
+                       "built-in representations for Time, Date, and Timestamp, "
                        + "which uses millisecond precision regardless of the database columns' precision.");
 
   public static final Field BIGINT_UNSIGNED_HANDLING_MODE = Field.create("bigint.unsigned.handling.mode")
@@ -897,18 +943,25 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
     .withDescription("Specify how BIGINT UNSIGNED columns should be represented in change events, including:"
-                       + "'precise' uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; "
-                       + "'long' (the default) represents values using Java's 'long', which may not offer the precision but will be far easier to use in consumers.");
+                       + "'precise' uses java.math.BigDecimal to represent values, which are encoded in the change" +
+                       " events using a binary representation and Kafka Connect's " +
+                       "'org.apache.kafka.connect.data.Decimal' type; "
+                       + "'long' (the default) represents values using Java's 'long', which may not offer the" +
+                       " precision but will be far easier to use in consumers.");
 
-  public static final Field EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE = Field.create("event.deserialization.failure.handling.mode")
+  public static final Field EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE
+    = Field.create("event.deserialization.failure.handling.mode")
     .withDisplayName("Event deserialization failure handling")
     .withEnum(EventProcessingFailureHandlingMode.class, EventProcessingFailureHandlingMode.FAIL)
     .withValidation(MySqlConnectorConfig::validateEventDeserializationFailureHandlingModeNotSet)
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
-    .withDescription("Specify how failures during deserialization of binlog events (i.e. when encountering a corrupted event) should be handled, including:"
-                       + "'fail' (the default) an exception indicating the problematic event and its binlog position is raised, causing the connector to be stopped; "
-                       + "'warn' the problematic event and its binlog position will be logged and the event will be skipped;"
+    .withDescription("Specify how failures during deserialization of binlog events (i.e. when encountering a" +
+                       " corrupted event) should be handled, including:"
+                       + "'fail' (the default) an exception indicating the problematic event and its binlog" +
+                       " position is raised, causing the connector to be stopped; "
+                       + "'warn' the problematic event and its binlog position will be logged and the event" +
+                       " will be skipped;"
                        + "'ignore' the problematic event will be skipped.");
 
   public static final Field INCONSISTENT_SCHEMA_HANDLING_MODE = Field.create("inconsistent.schema.handling.mode")
@@ -918,8 +971,10 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.SHORT)
     .withImportance(Importance.MEDIUM)
     .withDescription(
-      "Specify how binlog events that belong to a table missing from internal schema representation (i.e. internal representation is not consistent with database) should be handled, including:"
-        + "'fail' (the default) an exception indicating the problematic event and its binlog position is raised, causing the connector to be stopped; "
+      "Specify how binlog events that belong to a table missing from internal schema representation (i.e. internal" +
+        " representation is not consistent with database) should be handled, including:"
+        + "'fail' (the default) an exception indicating the problematic event and its binlog position is raised," +
+        " causing the connector to be stopped; "
         + "'warn' the problematic event and its binlog position will be logged and the event will be skipped;"
         + "'skip' the problematic event will be skipped.");
 
@@ -930,29 +985,36 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     .withWidth(Width.SHORT)
     .withImportance(Importance.LOW)
     .withDescription(
-      "MySQL allows user to insert year value as either 2-digit or 4-digit. In case of two digit the value is automatically mapped into 1970 - 2069." +
+      "MySQL allows user to insert year value as either 2-digit or 4-digit. In case of two digit the value is" +
+        " automatically mapped into 1970 - 2069." +
         "false - delegates the implicit conversion to the database" +
         "true - (the default) Debezium makes the conversion");
 
   /**
    * The set of {@link Field}s defined as part of this configuration.
    */
-  public static Field.Set ALL_FIELDS = Field.setOf(USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS, SERVER_ID, SERVER_ID_OFFSET,
+  public static Field.Set ALL_FIELDS = Field.setOf(USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS, SERVER_ID,
+                                                   SERVER_ID_OFFSET,
                                                    SERVER_NAME,
                                                    CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS,
                                                    CommonConnectorConfig.MAX_QUEUE_SIZE,
                                                    CommonConnectorConfig.MAX_BATCH_SIZE,
                                                    CommonConnectorConfig.POLL_INTERVAL_MS,
                                                    BUFFER_SIZE_FOR_BINLOG_READER, Heartbeat.HEARTBEAT_INTERVAL,
-                                                   Heartbeat.HEARTBEAT_TOPICS_PREFIX, DATABASE_HISTORY, INCLUDE_SCHEMA_CHANGES, INCLUDE_SQL_QUERY,
-                                                   TABLE_WHITELIST, TABLE_INCLUDE_LIST, TABLE_BLACKLIST, TABLE_EXCLUDE_LIST, TABLES_IGNORE_BUILTIN,
-                                                   DATABASE_WHITELIST, DATABASE_INCLUDE_LIST, DATABASE_BLACKLIST, DATABASE_EXCLUDE_LIST,
-                                                   COLUMN_BLACKLIST, COLUMN_EXCLUDE_LIST, COLUMN_INCLUDE_LIST, MSG_KEY_COLUMNS,
+                                                   Heartbeat.HEARTBEAT_TOPICS_PREFIX, DATABASE_HISTORY,
+                                                   INCLUDE_SCHEMA_CHANGES, INCLUDE_SQL_QUERY,
+                                                   TABLE_WHITELIST, TABLE_INCLUDE_LIST, TABLE_BLACKLIST,
+                                                   TABLE_EXCLUDE_LIST, TABLES_IGNORE_BUILTIN,
+                                                   DATABASE_WHITELIST, DATABASE_INCLUDE_LIST, DATABASE_BLACKLIST,
+                                                   DATABASE_EXCLUDE_LIST,
+                                                   COLUMN_BLACKLIST, COLUMN_EXCLUDE_LIST, COLUMN_INCLUDE_LIST,
+                                                   MSG_KEY_COLUMNS,
                                                    RelationalDatabaseConnectorConfig.MASK_COLUMN_WITH_HASH,
                                                    RelationalDatabaseConnectorConfig.MASK_COLUMN,
                                                    RelationalDatabaseConnectorConfig.TRUNCATE_COLUMN,
                                                    SNAPSHOT_MODE, SNAPSHOT_NEW_TABLES, SNAPSHOT_LOCKING_MODE,
-                                                   RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
+                                                   RelationalDatabaseConnectorConfig
+                                                     .SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
                                                    GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES,
                                                    GTID_SOURCE_FILTER_DML_EVENTS,
                                                    GTID_NEW_CHANNEL_POSITION,
@@ -972,9 +1034,9 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
   /**
    * The set of {@link Field}s that are included in the {@link #configDef() configuration definition}. This includes
-   * all fields defined in this class (though some are always invisible since they are not to be exposed to the user interface)
-   * plus several that are specific to the {@link KafkaDatabaseHistory} class, since history is always stored in Kafka
-   * when run via the user interface.
+   * all fields defined in this class (though some are always invisible since they are not to be exposed to the user
+   * interface) plus several that are specific to the {@link KafkaDatabaseHistory} class, since history is always
+   * stored in Kafka when run via the user interface.
    */
   protected static Field.Set EXPOSED_FIELDS = ALL_FIELDS.with(KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
                                                               KafkaDatabaseHistory.TOPIC,
@@ -999,13 +1061,17 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
       DEFAULT_SNAPSHOT_FETCH_SIZE);
 
     this.temporalPrecisionMode = TemporalPrecisionMode.parse(config.getString(TIME_PRECISION_MODE));
-    this.snapshotLockingMode = SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE), SNAPSHOT_LOCKING_MODE.defaultValueAsString());
+    this.snapshotLockingMode = SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE),
+                                                         SNAPSHOT_LOCKING_MODE.defaultValueAsString());
 
     String gitIdNewChannelPosition = config.getString(MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION);
-    this.gitIdNewChannelPosition = GtidNewChannelPosition.parse(gitIdNewChannelPosition, MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION.defaultValueAsString());
+    this.gitIdNewChannelPosition
+      = GtidNewChannelPosition.parse(gitIdNewChannelPosition,
+                                     MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION.defaultValueAsString());
 
     String snapshotNewTables = config.getString(MySqlConnectorConfig.SNAPSHOT_NEW_TABLES);
-    this.snapshotNewTables = SnapshotNewTables.parse(snapshotNewTables, MySqlConnectorConfig.SNAPSHOT_NEW_TABLES.defaultValueAsString());
+    this.snapshotNewTables = SnapshotNewTables.parse(snapshotNewTables,
+                                                     MySqlConnectorConfig.SNAPSHOT_NEW_TABLES.defaultValueAsString());
 
     this.connectionTimeout = Duration.ofMillis(config.getLong(MySqlConnectorConfig.CONNECTION_TIMEOUT_MS));
   }
@@ -1024,8 +1090,10 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
   protected static ConfigDef configDef() {
     ConfigDef config = new ConfigDef();
-    Field.group(config, "MySQL", HOSTNAME, PORT, USER, PASSWORD, ON_CONNECT_STATEMENTS, SERVER_NAME, SERVER_ID, SERVER_ID_OFFSET,
-                SSL_MODE, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD, SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD, JDBC_DRIVER, CommonConnectorConfig.SKIPPED_OPERATIONS);
+    Field.group(config, "MySQL", HOSTNAME, PORT, USER, PASSWORD, ON_CONNECT_STATEMENTS, SERVER_NAME, SERVER_ID,
+                SERVER_ID_OFFSET,
+                SSL_MODE, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD, SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD, JDBC_DRIVER,
+                CommonConnectorConfig.SKIPPED_OPERATIONS);
     Field.group(config, "History Storage", KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
                 KafkaDatabaseHistory.TOPIC, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
                 KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, DATABASE_HISTORY,
@@ -1039,25 +1107,32 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
                 RelationalDatabaseConnectorConfig.MASK_COLUMN,
                 RelationalDatabaseConnectorConfig.TRUNCATE_COLUMN,
                 RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
-                GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS, GTID_NEW_CHANNEL_POSITION, BUFFER_SIZE_FOR_BINLOG_READER,
-                Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX, EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE,
+                GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS, GTID_NEW_CHANNEL_POSITION,
+                BUFFER_SIZE_FOR_BINLOG_READER,
+                Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX,
+                EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE,
                 CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE, INCONSISTENT_SCHEMA_HANDLING_MODE,
                 CommonConnectorConfig.TOMBSTONES_ON_DELETE, CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION);
-    Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS, CommonConnectorConfig.MAX_QUEUE_SIZE,
+    Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS,
+                CommonConnectorConfig.MAX_QUEUE_SIZE,
                 CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
                 SNAPSHOT_MODE, SNAPSHOT_LOCKING_MODE, SNAPSHOT_NEW_TABLES, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
-                BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_DELAY_MS, SNAPSHOT_FETCH_SIZE, ENABLE_TIME_ADJUSTER, BINARY_HANDLING_MODE);
+                BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_DELAY_MS, SNAPSHOT_FETCH_SIZE, ENABLE_TIME_ADJUSTER,
+                BINARY_HANDLING_MODE);
     return config;
   }
 
-  private static int validateGtidNewChannelPositionNotSet(Configuration config, Field field, ValidationOutput problems) {
+  private static int validateGtidNewChannelPositionNotSet(Configuration config, Field field,
+                                                          ValidationOutput problems) {
     if (config.getString(GTID_NEW_CHANNEL_POSITION.name()) != null) {
-      LOGGER.warn("Configuration option '{}' is deprecated and scheduled for removal", GTID_NEW_CHANNEL_POSITION.name());
+      LOGGER.warn("Configuration option '{}' is deprecated and scheduled for removal",
+                  GTID_NEW_CHANNEL_POSITION.name());
     }
     return 0;
   }
 
-  private static int validateEventDeserializationFailureHandlingModeNotSet(Configuration config, Field field, ValidationOutput problems) {
+  private static int validateEventDeserializationFailureHandlingModeNotSet(Configuration config, Field field,
+                                                                           ValidationOutput problems) {
     final String modeName = config.asMap().get(EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE.name());
     if (modeName != null) {
       LOGGER.warn("Configuration option '{}' is renamed to '{}'", EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE.name(),
@@ -1072,7 +1147,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     return 0;
   }
 
-  private static int validateInconsistentSchemaHandlingModeNotIgnore(Configuration config, Field field, ValidationOutput problems) {
+  private static int validateInconsistentSchemaHandlingModeNotIgnore(Configuration config, Field field,
+                                                                     ValidationOutput problems) {
     final String modeName = config.getString(INCONSISTENT_SCHEMA_HANDLING_MODE);
     if (EventProcessingFailureHandlingMode.OBSOLETE_NAME_FOR_SKIP_FAILURE_HANDLING.equals(modeName)) {
       LOGGER.warn("Value '{}' of configuration option '{}' is deprecated and should be replaced with '{}'",
@@ -1142,7 +1218,8 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
       final String timePrecisionMode = config.getString(TIME_PRECISION_MODE.name());
       if (TemporalPrecisionMode.ADAPTIVE.getValue().equals(timePrecisionMode)) {
         // this is a problem
-        problems.accept(TIME_PRECISION_MODE, timePrecisionMode, "The 'adaptive' time.precision.mode is no longer supported");
+        problems.accept(TIME_PRECISION_MODE, timePrecisionMode, "The 'adaptive' time.precision.mode is no " +
+          "longer supported");
         return 1;
       }
     }

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -92,9 +92,7 @@ public class MySqlJdbcContext implements AutoCloseable {
 
     jdbcConfig = jdbcConfigBuilder.build();
     String driverClassName = jdbcConfig.getString(MySqlConnectorConfig.JDBC_DRIVER);
-    this.jdbc = new JdbcConnection(jdbcConfig,
-                                   JdbcConnection.patternBasedFactory(MYSQL_CONNECTION_URL, driverClassName,
-                                                                      getClass().getClassLoader()));
+    this.jdbc = new JdbcConnection(jdbcConfig, connectionFactory);
   }
 
   public Configuration config() {

--- a/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/mysql-delta-plugins/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -5,6 +5,29 @@
  */
 package io.debezium.connector.mysql;
 
+import com.github.shyiko.mysql.binlog.event.deserialization.AbstractRowsEventDataDeserializer;
+import com.github.shyiko.mysql.binlog.event.deserialization.json.JsonBinary;
+import io.debezium.DebeziumException;
+import io.debezium.annotation.Immutable;
+import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
+import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
+import io.debezium.data.Json;
+import io.debezium.jdbc.JdbcValueConverters;
+import io.debezium.jdbc.TemporalPrecisionMode;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.ValueConverter;
+import io.debezium.time.Year;
+import io.debezium.util.Strings;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -27,41 +50,17 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.kafka.connect.data.Decimal;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.source.SourceRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.shyiko.mysql.binlog.event.deserialization.AbstractRowsEventDataDeserializer;
-import com.github.shyiko.mysql.binlog.event.deserialization.json.JsonBinary;
-
-import io.debezium.DebeziumException;
-import io.debezium.annotation.Immutable;
-import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
-import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
-import io.debezium.data.Json;
-import io.debezium.jdbc.JdbcValueConverters;
-import io.debezium.jdbc.TemporalPrecisionMode;
-import io.debezium.relational.Column;
-import io.debezium.relational.Table;
-import io.debezium.relational.ValueConverter;
-import io.debezium.time.Year;
-import io.debezium.util.Strings;
-
 /**
  * MySQL-specific customization of the conversions from JDBC values obtained from the MySQL binlog client library.
  * <p>
- * This class always uses UTC for the default time zone when converting values without timezone information to values that require
- * timezones. This is because MySQL {@code TIMESTAMP} values are always
- * <a href="https://dev.mysql.com/doc/refman/5.7/en/datetime.html">stored in UTC</a> (unlike {@code DATETIME} values) and
- * are replicated in this form. Meanwhile, the MySQL Binlog Client library will {@link AbstractRowsEventDataDeserializer
- * deserialize} these as {@link java.sql.Timestamp} values that have no timezone and, therefore, are presumed to be in UTC.
- * When the column is properly marked with a {@link Types#TIMESTAMP_WITH_TIMEZONE} type, the converters will need to convert
- * that {@link java.sql.Timestamp} value into an {@link OffsetDateTime} using the default time zone, which always is UTC.
+ * This class always uses UTC for the default time zone when converting values without timezone information to values
+ * that require timezones. This is because MySQL {@code TIMESTAMP} values are always
+ * <a href="https://dev.mysql.com/doc/refman/5.7/en/datetime.html">stored in UTC</a> (unlike {@code DATETIME} values)
+ * and are replicated in this form. Meanwhile, the MySQL Binlog Client library will
+ * {@link AbstractRowsEventDataDeserializer deserialize} these as {@link java.sql.Timestamp} values that have no
+ * timezone and, therefore, are presumed to be in UTC. When the column is properly marked with a
+ * {@link Types#TIMESTAMP_WITH_TIMEZONE} type, the converters will need to convert that {@link java.sql.Timestamp}
+ * value into an {@link OffsetDateTime} using the default time zone, which always is UTC.
  *
  * @author Randall Hauch
  * @see com.github.shyiko.mysql.binlog.event.deserialization.AbstractRowsEventDataDeserializer
@@ -69,8 +68,11 @@ import io.debezium.util.Strings;
 @Immutable
 public class MySqlValueConverters extends JdbcValueConverters {
 
+  /**
+   *
+   */
   @FunctionalInterface
-  public static interface ParsingErrorHandler {
+  public interface ParsingErrorHandler {
     void error(String message, Exception exception);
   }
 
@@ -100,8 +102,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
   public static ClassLoader jdbcClassLoader;
 
   /**
-   * A utility method that adjusts <a href="https://dev.mysql.com/doc/refman/5.7/en/two-digit-years.html">ambiguous</a> 2-digit
-   * year values of DATETIME, DATE, and TIMESTAMP types using these MySQL-specific rules:
+   * A utility method that adjusts <a href="https://dev.mysql.com/doc/refman/5.7/en/two-digit-years.html">ambiguous</a>
+   * 2-digit year values of DATETIME, DATE, and TIMESTAMP types using these MySQL-specific rules:
    * <ul>
    * <li>Year values in the range 00-69 are converted to 2000-2069.</li>
    * <li>Year values in the range 70-99 are converted to 1970-1999.</li>
@@ -115,8 +117,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
       int year = temporal.get(ChronoField.YEAR);
       if (0 <= year && year <= 69) {
         temporal = temporal.plus(2000, ChronoUnit.YEARS);
-      }
-      else if (70 <= year && year <= 99) {
+      } else if (70 <= year && year <= 99) {
         temporal = temporal.plus(1900, ChronoUnit.YEARS);
       }
     }
@@ -126,8 +127,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
   private final ParsingErrorHandler parsingErrorHandler;
 
   /**
-   * Create a new instance that always uses UTC for the default time zone when_needed converting values without timezone information
-   * to values that require timezones.
+   * Create a new instance that always uses UTC for the default time zone when_needed converting values without
+   * timezone information to values that require timezones.
    * <p>
    *
    * @param decimalMode how {@code DECIMAL} and {@code NUMERIC} values should be treated; may be null if
@@ -137,16 +138,16 @@ public class MySqlValueConverters extends JdbcValueConverters {
    *            {@link io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode#PRECISE} is to be used
    * @param binaryMode how binary columns should be represented
    */
-  public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode, BigIntUnsignedMode bigIntUnsignedMode,
-                              BinaryHandlingMode binaryMode) {
+  public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode,
+                              BigIntUnsignedMode bigIntUnsignedMode, BinaryHandlingMode binaryMode) {
     this(decimalMode, temporalPrecisionMode, bigIntUnsignedMode, binaryMode, x -> x, (message, exception) -> {
       throw new DebeziumException(message, exception);
     });
   }
 
   /**
-   * Create a new instance that always uses UTC for the default time zone when converting values without timezone information
-   * to values that require timezones.
+   * Create a new instance that always uses UTC for the default time zone when converting values without timezone
+   * information to values that require timezones.
    * <p>
    *
    * @param decimalMode how {@code DECIMAL} and {@code NUMERIC} values should be treated; may be null if
@@ -156,7 +157,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
    *            {@link io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode#PRECISE} is to be used
    * @param binaryMode how binary columns should be represented
    * @param adjuster a temporal adjuster to make a database specific time modification before conversion
-   * @param handler for errors during postponed binlog parsing
+   * @param parsingErrorHandler for errors during postponed binlog parsing
    */
   public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode,
                               BigIntUnsignedMode bigIntUnsignedMode, BinaryHandlingMode binaryMode,
@@ -202,7 +203,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
     }
     if (matches(typeName, "SMALLINT UNSIGNED") || matches(typeName, "SMALLINT UNSIGNED ZEROFILL")
       || matches(typeName, "INT2 UNSIGNED") || matches(typeName, "INT2 UNSIGNED ZEROFILL")) {
-      // In order to capture unsigned SMALLINT 16-bit data source, INT32 will be required to safely capture all valid values
+      // In order to capture unsigned SMALLINT 16-bit data source, INT32 will be required to safely capture all valid
+      // values
       // Source: https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/data/Schema.Type.html
       return SchemaBuilder.int32();
     }
@@ -218,7 +220,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
         case LONG:
           return SchemaBuilder.int64();
         case PRECISE:
-          // In order to capture unsigned INT 64-bit data source, org.apache.kafka.connect.data.Decimal:Byte will be required to safely capture all valid values with scale of 0
+          // In order to capture unsigned INT 64-bit data source, org.apache.kafka.connect.data.Decimal:Byte will be
+          // required to safely capture all valid values with scale of 0
           // Source: https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/data/Schema.Type.html
           return Decimal.builder(0);
       }
@@ -315,8 +318,11 @@ public class MySqlValueConverters extends JdbcValueConverters {
         if (adaptiveTimeMicrosecondsPrecisionMode) {
           return data -> convertDurationToMicroseconds(column, fieldDefn, data);
         }
+        return ((ValueConverter) (data -> convertTimestampToLocalDateTime(column, fieldDefn, data)))
+          .and(super.converter(column, fieldDefn));
       case Types.TIMESTAMP:
-        return ((ValueConverter) (data -> convertTimestampToLocalDateTime(column, fieldDefn, data))).and(super.converter(column, fieldDefn));
+        return ((ValueConverter) (data -> convertTimestampToLocalDateTime(column, fieldDefn, data)))
+          .and(super.converter(column, fieldDefn));
       default:
         break;
     }
@@ -354,14 +360,14 @@ public class MySqlValueConverters extends JdbcValueConverters {
     // end change from original file
 
     if (encoding == null) {
-      logger.warn("Column uses MySQL character set '{}', which has no mapping to a Java character set", mySqlCharsetName);
-    }
-    else {
+      logger.warn("Column uses MySQL character set '{}', which has no mapping to a Java character set",
+                  mySqlCharsetName);
+    } else {
       try {
         return Charset.forName(encoding);
-      }
-      catch (IllegalCharsetNameException e) {
-        logger.error("Unable to load Java charset '{}' for column with MySQL character set '{}'", encoding, mySqlCharsetName);
+      } catch (IllegalCharsetNameException e) {
+        logger.error("Unable to load Java charset '{}' for column with MySQL character set '{}'", encoding,
+                     mySqlCharsetName);
       }
     }
     return null;
@@ -384,18 +390,16 @@ public class MySqlValueConverters extends JdbcValueConverters {
 
         if (((byte[]) data).length == 0) {
           r.deliver(column.isOptional() ? null : "{}");
-        }
-        else {
+        } else {
           try {
             r.deliver(JsonBinary.parseAsString((byte[]) data));
-          }
-          catch (IOException e) {
-            parsingErrorHandler.error("Failed to parse and read a JSON value on '" + column + "' value " + Arrays.toString((byte[]) data), e);
+          } catch (IOException e) {
+            parsingErrorHandler.error("Failed to parse and read a JSON value on '" + column + "' value " +
+                                        Arrays.toString((byte[]) data), e);
             r.deliver(column.isOptional() ? null : "{}");
           }
         }
-      }
-      else if (data instanceof String) {
+      } else if (data instanceof String) {
         // The SnapshotReader sees JSON values as UTF-8 encoded strings.
         r.deliver(data);
       }
@@ -417,8 +421,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
       if (data instanceof byte[]) {
         // Decode the binary representation using the given character encoding ...
         r.deliver(new String((byte[]) data, columnCharset));
-      }
-      else if (data instanceof String) {
+      } else if (data instanceof String) {
         r.deliver(data);
       }
     });
@@ -441,13 +444,11 @@ public class MySqlValueConverters extends JdbcValueConverters {
       if (data instanceof java.time.Year) {
         // The MySQL binlog always returns a Year object ...
         r.deliver(adjustTemporal(java.time.Year.of(((java.time.Year) data).getValue())).get(ChronoField.YEAR));
-      }
-      else if (data instanceof java.sql.Date) {
+      } else if (data instanceof java.sql.Date) {
         // MySQL JDBC driver sometimes returns a Java SQL Date object ...
         // year from java.sql.Date is defined as number of years since 1900
         r.deliver(((java.sql.Date) data).getYear() + 1900);
-      }
-      else if (data instanceof String) {
+      } else if (data instanceof String) {
         mutData = Integer.valueOf((String) data);
       }
       if (mutData instanceof Number) {
@@ -458,8 +459,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
   }
 
   /**
-   * Converts a value object for a MySQL {@code ENUM}, which is represented in the binlog events as an integer value containing
-   * the index of the enum option. The MySQL JDBC driver returns a string containing the option,
+   * Converts a value object for a MySQL {@code ENUM}, which is represented in the binlog events as an integer value
+   * containing the index of the enum option. The MySQL JDBC driver returns a string containing the option,
    * so this method calculates the same.
    *
    * @param options the characters that appear in the same order as defined in the column; may not be null
@@ -474,8 +475,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
       if (data instanceof String) {
         // JDBC should return strings ...
         r.deliver(data);
-      }
-      else if (data instanceof Integer) {
+      } else if (data instanceof Integer) {
         if (options != null) {
           // The binlog will contain an int with the 1-based index of the option in the enum value ...
           int value = ((Integer) data).intValue();
@@ -487,8 +487,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
           if (index < options.size() && index >= 0) {
             r.deliver(options.get(index));
           }
-        }
-        else {
+        } else {
           r.deliver(null);
         }
       }
@@ -496,9 +495,9 @@ public class MySqlValueConverters extends JdbcValueConverters {
   }
 
   /**
-   * Converts a value object for a MySQL {@code SET}, which is represented in the binlog events contain a long number in which
-   * every bit corresponds to a different option. The MySQL JDBC driver returns a string containing the comma-separated options,
-   * so this method calculates the same.
+   * Converts a value object for a MySQL {@code SET}, which is represented in the binlog events contain a long number
+   * in which every bit corresponds to a different option. The MySQL JDBC driver returns a string containing the
+   * comma-separated options, so this method calculates the same.
    *
    * @param options the characters that appear in the same order as defined in the column; may not be null
    * @param column the column definition describing the {@code data} value; never null
@@ -512,8 +511,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
       if (data instanceof String) {
         // JDBC should return strings ...
         r.deliver(data);
-      }
-      else if (data instanceof Long) {
+      } else if (data instanceof Long) {
         // The binlog will contain a long with the indexes of the options in the set value ...
         long indexes = ((Long) data).longValue();
         r.deliver(convertSetValue(column, indexes, options));
@@ -523,7 +521,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
 
   /**
    * Determine if the uppercase form of a column's type exactly matches or begins with the specified prefix.
-   * Note that this logic works when the column's {@link Column#typeName() type} contains the type name followed by parentheses.
+   * Note that this logic works when the column's {@link Column#typeName() type} contains the type name followed by
+   * parentheses.
    *
    * @param upperCaseTypeName the upper case form of the column's {@link Column#typeName() type name}
    * @param upperCaseMatch the upper case form of the expected type or prefix of the type; may not be null
@@ -537,7 +536,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
   }
 
   /**
-   * Determine if the uppercase form of a column's type is geometry collection independent of JDBC driver or server version.
+   * Determine if the uppercase form of a column's type is geometry collection independent of JDBC driver or server
+   * version.
    *
    * @param upperCaseTypeName the upper case form of the column's {@link Column#typeName() type name}
    * @return {@code true} if the type is geometry collection
@@ -568,14 +568,12 @@ public class MySqlValueConverters extends JdbcValueConverters {
       if (indexes % 2L != 0) {
         if (first) {
           first = false;
-        }
-        else {
+        } else {
           sb.append(',');
         }
         if (index < optionLen) {
           sb.append(options.get(index));
-        }
-        else {
+        } else {
           logger.warn("Found unexpected index '{}' on column {}", index, column);
         }
       }
@@ -597,15 +595,17 @@ public class MySqlValueConverters extends JdbcValueConverters {
    */
   protected Object convertPoint(Column column, Field fieldDefn, Object data) {
     final MySqlGeometry empty = MySqlGeometry.createEmpty();
-    return convertValue(column, fieldDefn, data, io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(), empty.getWkb(), empty.getSrid()), (r) -> {
+    return convertValue(column, fieldDefn, data,
+                        io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(), empty.getWkb(),
+                                                                       empty.getSrid()), (r) -> {
       if (data instanceof byte[]) {
-        // The binlog utility sends a byte array for any Geometry type, we will use our own binaryParse to parse the byte to WKB, hence
-        // to the suitable class
+        // The binlog utility sends a byte array for any Geometry type, we will use our own binaryParse to parse the
+        // byte to WKB, hence to the suitable class
         MySqlGeometry mySqlGeometry = MySqlGeometry.fromBytes((byte[]) data);
         if (mySqlGeometry.isPoint()) {
-          r.deliver(io.debezium.data.geometry.Point.createValue(fieldDefn.schema(), mySqlGeometry.getWkb(), mySqlGeometry.getSrid()));
-        }
-        else {
+          r.deliver(io.debezium.data.geometry.Point.createValue(fieldDefn.schema(), mySqlGeometry.getWkb(),
+                                                                mySqlGeometry.getSrid()));
+        } else {
           throw new ConnectException("Failed to parse and read a value of type POINT on " + column);
         }
       }
@@ -613,7 +613,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
   }
 
   /**
-   * Convert the a value representing a GEOMETRY {@code byte[]} value to a Geometry value used in a {@link SourceRecord}.
+   * Convert the a value representing a GEOMETRY {@code byte[]} value to a Geometry value used in a
+   * {@link SourceRecord}.
    *
    * @param column the column in which the value appears
    * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
@@ -623,15 +624,18 @@ public class MySqlValueConverters extends JdbcValueConverters {
    */
   protected Object convertGeometry(Column column, Field fieldDefn, Object data) {
     final MySqlGeometry empty = MySqlGeometry.createEmpty();
-    return convertValue(column, fieldDefn, data, io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(), empty.getWkb(), empty.getSrid()), (r) -> {
+    return convertValue(column, fieldDefn, data,
+                        io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(), empty.getWkb(),
+                                                                       empty.getSrid()), (r) -> {
       if (data instanceof byte[]) {
-        // The binlog utility sends a byte array for any Geometry type, we will use our own binaryParse to parse the byte to WKB, hence
-        // to the suitable class
+        // The binlog utility sends a byte array for any Geometry type, we will use our own binaryParse to parse the
+        // byte to WKB, hence to the suitable class
         if (data instanceof byte[]) {
-          // The binlog utility sends a byte array for any Geometry type, we will use our own binaryParse to parse the byte to WKB, hence
-          // to the suitable class
+          // The binlog utility sends a byte array for any Geometry type, we will use our own binaryParse to parse the
+          // byte to WKB, hence to the suitable class
           MySqlGeometry mySqlGeometry = MySqlGeometry.fromBytes((byte[]) data);
-          r.deliver(io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(), mySqlGeometry.getWkb(), mySqlGeometry.getSrid()));
+          r.deliver(io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(), mySqlGeometry.getWkb(),
+                                                                   mySqlGeometry.getSrid()));
         }
       }
     });
@@ -662,11 +666,9 @@ public class MySqlValueConverters extends JdbcValueConverters {
     return convertValue(column, fieldDefn, data, (short) 0, (r) -> {
       if (data instanceof Short) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedTinyint((short) data));
-      }
-      else if (data instanceof Number) {
+      } else if (data instanceof Number) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedTinyint(((Number) data).shortValue()));
-      }
-      else {
+      } else {
         // We continue with the original converting method (smallint) since we have an unsigned Tinyint
         r.deliver(convertSmallInt(column, fieldDefn, data));
       }
@@ -688,11 +690,9 @@ public class MySqlValueConverters extends JdbcValueConverters {
     return convertValue(column, fieldDefn, data, 0, (r) -> {
       if (data instanceof Integer) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedSmallint((int) data));
-      }
-      else if (data instanceof Number) {
+      } else if (data instanceof Number) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedSmallint(((Number) data).intValue()));
-      }
-      else {
+      } else {
         // We continue with the original converting method (integer) since we have an unsigned Smallint
         r.deliver(convertInteger(column, fieldDefn, data));
       }
@@ -714,11 +714,9 @@ public class MySqlValueConverters extends JdbcValueConverters {
     return convertValue(column, fieldDefn, data, 0, (r) -> {
       if (data instanceof Integer) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedMediumint((int) data));
-      }
-      else if (data instanceof Number) {
+      } else if (data instanceof Number) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedMediumint(((Number) data).intValue()));
-      }
-      else {
+      } else {
         // We continue with the original converting method (integer) since we have an unsigned Medium
         r.deliver(convertInteger(column, fieldDefn, data));
       }
@@ -740,11 +738,9 @@ public class MySqlValueConverters extends JdbcValueConverters {
     return convertValue(column, fieldDefn, data, 0L, (r) -> {
       if (data instanceof Long) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedInteger((long) data));
-      }
-      else if (data instanceof Number) {
+      } else if (data instanceof Number) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedInteger(((Number) data).longValue()));
-      }
-      else {
+      } else {
         // We continue with the original converting method (bigint) since we have an unsigned Integer
         r.deliver(convertBigInt(column, fieldDefn, data));
       }
@@ -766,14 +762,11 @@ public class MySqlValueConverters extends JdbcValueConverters {
     return convertValue(column, fieldDefn, data, 0L, (r) -> {
       if (data instanceof BigDecimal) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedBigint((BigDecimal) data));
-      }
-      else if (data instanceof Number) {
+      } else if (data instanceof Number) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedBigint(new BigDecimal(((Number) data).toString())));
-      }
-      else if (data instanceof String) {
+      } else if (data instanceof String) {
         r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedBigint(new BigDecimal((String) data)));
-      }
-      else {
+      } else {
         r.deliver(convertNumeric(column, fieldDefn, data));
       }
     });
@@ -800,8 +793,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
         if (data instanceof Duration) {
           r.deliver(((Duration) data).toNanos() / 1_000);
         }
-      }
-      catch (IllegalArgumentException e) {
+      } catch (IllegalArgumentException e) {
       }
     });
   }
@@ -837,8 +829,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
         .plusMinutes(minutes)
         .plusSeconds(seconds)
         .plusNanos(nanoSeconds);
-    }
-    else {
+    } else {
       return Duration.ofHours(hours)
         .minusMinutes(minutes)
         .minusSeconds(seconds)
@@ -857,7 +848,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
     final int day = Integer.parseInt(matcher.group(3));
 
     if (year == 0 || month == 0 || day == 0) {
-      LOGGER.warn("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value", dateString, column.name(), table.id());
+      LOGGER.warn("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value", dateString,
+                  column.name(), table.id());
       return null;
     }
     return LocalDate.of(year, month, day);
@@ -874,7 +866,8 @@ public class MySqlValueConverters extends JdbcValueConverters {
     final int day = Integer.parseInt(matcher.group(3));
 
     if (year == 0 || month == 0 || day == 0) {
-      LOGGER.warn("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value", timestampString, column.name(), table.id());
+      LOGGER.warn("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value", timestampString,
+                  column.name(), table.id());
       return true;
     }
     return false;

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,10 @@
   </scm>
 
   <properties>
-    <debezium.version>0.9.5.Final</debezium.version>
     <delta.version>0.3.0-SNAPSHOT</delta.version>
+    <debezium.version>1.3.1.Final</debezium.version>
     <slf4j.version>1.7.25</slf4j.version>
+    <guava.version>30.0-jre</guava.version>
   </properties>
 
   <repositories>
@@ -124,6 +125,11 @@
       <groupId>io.cdap.delta</groupId>
       <artifactId>delta-api</artifactId>
       <version>${delta.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
   </dependencies>
 

--- a/sqlserver-delta-plugins/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/sqlserver-delta-plugins/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -6,71 +6,138 @@
 
 package io.debezium.connector.sqlserver;
 
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.Column;
 import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.BoundedConcurrentHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import io.debezium.util.Clock;
 
 /**
  * {@link JdbcConnection} extension to be used with Microsoft SQL Server
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com), Jiri Pechanec
+ *
  */
 public class SqlServerConnection extends JdbcConnection {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerConnection.class);
+
+  public static final String SERVER_TIMEZONE_PROP_NAME = "server.timezone";
+  public static final String INSTANCE_NAME = "instance";
 
   private static final String GET_DATABASE_NAME = "SELECT db_name()";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerConnection.class);
+
   private static final String STATEMENTS_PLACEHOLDER = "#";
   private static final String GET_MAX_LSN = "SELECT sys.fn_cdc_get_max_lsn()";
+  private static final String GET_MIN_LSN = "SELECT sys.fn_cdc_get_min_lsn('#')";
   private static final String LOCK_TABLE = "SELECT * FROM [#] WITH (TABLOCKX)";
-  private static final String LSN_TO_TIMESTAMP = "SELECT sys.fn_cdc_map_lsn_to_time(?)";
+  private static final String SQL_SERVER_VERSION = "SELECT @@VERSION AS 'SQL Server Version'";
+  private final String lsnToTimestamp;
   private static final String INCREMENT_LSN = "SELECT sys.fn_cdc_increment_lsn(?)";
-  private static final String GET_ALL_CHANGES_FOR_TABLE =
-    "SELECT * FROM cdc.[fn_cdc_get_all_changes_#](ISNULL(?,sys.fn_cdc_get_min_lsn('#')), ?, N'all update old')";
+  private static final String GET_ALL_CHANGES_FOR_TABLE = "SELECT * FROM cdc.[fn_cdc_get_all_changes_#](?, ?, N'all update old')";
   private static final String GET_LIST_OF_CDC_ENABLED_TABLES = "EXEC sys.sp_cdc_help_change_data_capture";
-  private static final String GET_LIST_OF_NEW_CDC_ENABLED_TABLES =
-    "SELECT * FROM cdc.change_tables WHERE start_lsn BETWEEN ? AND ?";
+  private static final String GET_LIST_OF_NEW_CDC_ENABLED_TABLES = "SELECT * FROM cdc.change_tables WHERE start_lsn BETWEEN ? AND ?";
   private static final String GET_LIST_OF_KEY_COLUMNS = "SELECT * FROM cdc.index_columns WHERE object_id=?";
+  private static final Pattern BRACKET_PATTERN = Pattern.compile("[\\[\\]]");
+
   private static final int CHANGE_TABLE_DATA_COLUMN_OFFSET = 5;
 
-  // Note: this line is the only change from the original file
+  private static final String URL_PATTERN = "jdbc:sqlserver://${" + JdbcConfiguration.HOSTNAME + "}:${" + JdbcConfiguration.PORT + "};databaseName=${"
+    + JdbcConfiguration.DATABASE + "}";
+
+  // Note: this line is the only change from the original file. Renamed variable to factory and
+  // made it public and non-final
   public static ConnectionFactory factory;
 
   /**
    * actual name of the database, which could differ in casing from the database name given in the connector config.
    */
   private final String realDatabaseName;
-
-  private interface ResultSetExtractor<T> {
-    T apply(ResultSet rs) throws SQLException;
-  }
+  private final ZoneId transactionTimezone;
+  private final SourceTimestampMode sourceTimestampMode;
+  private final Clock clock;
+  private final int queryFetchSize;
 
   private final BoundedConcurrentHashMap<Lsn, Instant> lsnToInstantCache;
+  private final SqlServerDefaultValueConverter defaultValueConverter;
 
   /**
    * Creates a new connection using the supplied configuration.
    *
    * @param config {@link Configuration} instance, may not be null.
+   * @param clock the clock
+   * @param sourceTimestampMode strategy for populating {@code source.ts_ms}.
+   * @param valueConverters {@link SqlServerValueConverters} instance
    */
-  public SqlServerConnection(Configuration config) {
-    super(config, factory);
+  public SqlServerConnection(Configuration config, Clock clock, SourceTimestampMode sourceTimestampMode, SqlServerValueConverters valueConverters) {
+    this(config, clock, sourceTimestampMode, valueConverters, null);
+  }
+
+  /**
+   * Creates a new connection using the supplied configuration.
+   *
+   * @param config {@link Configuration} instance, may not be null.
+   * @param clock the clock
+   * @param sourceTimestampMode strategy for populating {@code source.ts_ms}.
+   * @param valueConverters {@link SqlServerValueConverters} instance
+   * @param classLoaderSupplier class loader supplier
+   */
+  public SqlServerConnection(Configuration config, Clock clock, SourceTimestampMode sourceTimestampMode, SqlServerValueConverters valueConverters,
+                             Supplier<ClassLoader> classLoaderSupplier) {
+    super(config, FACTORY, classLoaderSupplier);
     lsnToInstantCache = new BoundedConcurrentHashMap<>(100);
     realDatabaseName = retrieveRealDatabaseName();
+    boolean supportsAtTimeZone = supportsAtTimeZone();
+    transactionTimezone = retrieveTransactionTimezone(supportsAtTimeZone);
+    lsnToTimestamp = getLsnToTimestamp(supportsAtTimeZone);
+    this.clock = clock;
+    this.sourceTimestampMode = sourceTimestampMode;
+    defaultValueConverter = new SqlServerDefaultValueConverter(this::connection, valueConverters);
+    this.queryFetchSize = config().getInteger(CommonConnectorConfig.QUERY_FETCH_SIZE);
+  }
+
+  /**
+   * Returns the query for obtaining the LSN-to-TIMESTAMP query. On SQL Server
+   * 2016 and newer, the query will normalize the value to UTC. This means that
+   * the {@link #SERVER_TIMEZONE_PROP_NAME} is not necessary to be given. The
+   * returned TIMESTAMP will be adjusted by the JDBC driver using this VM's TZ (as
+   * required by the JDBC spec), and that same TZ will be applied when converting
+   * the TIMESTAMP value into an {@code Instant}.
+   */
+  private static String getLsnToTimestamp(boolean supportsAtTimeZone) {
+    String lsnToTimestamp = "SELECT sys.fn_cdc_map_lsn_to_time(?)";
+
+    if (supportsAtTimeZone) {
+      lsnToTimestamp = lsnToTimestamp + " AT TIME ZONE 'UTC'";
+    }
+
+    return lsnToTimestamp;
   }
 
   /**
@@ -85,6 +152,18 @@ public class SqlServerConnection extends JdbcConnection {
   }
 
   /**
+   * @return the smallest log sequence number of table
+   */
+  public Lsn getMinLsn(String changeTableName) throws SQLException {
+    String query = GET_MIN_LSN.replace(STATEMENTS_PLACEHOLDER, changeTableName);
+    return queryAndMap(query, singleResultMapper(rs -> {
+      final Lsn ret = Lsn.valueOf(rs.getBytes(1));
+      LOGGER.trace("Current minimum lsn is {}", ret);
+      return ret;
+    }, "Minimum LSN query must return exactly one value"));
+  }
+
+  /**
    * Provides all changes recorded by the SQL Server CDC capture process for a given table.
    *
    * @param tableId - the requested table changes
@@ -93,8 +172,7 @@ public class SqlServerConnection extends JdbcConnection {
    * @param consumer - the change processor
    * @throws SQLException
    */
-  public void getChangesForTable(TableId tableId, Lsn fromLsn, Lsn toLsn, ResultSetConsumer consumer)
-    throws SQLException {
+  public void getChangesForTable(TableId tableId, Lsn fromLsn, Lsn toLsn, ResultSetConsumer consumer) throws SQLException {
     final String query = GET_ALL_CHANGES_FOR_TABLE.replace(STATEMENTS_PLACEHOLDER, cdcNameForTable(tableId));
     prepareQuery(query, statement -> {
       statement.setBytes(1, fromLsn.getBinary());
@@ -111,21 +189,23 @@ public class SqlServerConnection extends JdbcConnection {
    * @param consumer - the change processor
    * @throws SQLException
    */
-  public void getChangesForTables(ChangeTable[] changeTables, Lsn intervalFromLsn, Lsn intervalToLsn,
-                                  BlockingMultiResultSetConsumer consumer) throws SQLException, InterruptedException {
+  public void getChangesForTables(SqlServerChangeTable[] changeTables, Lsn intervalFromLsn, Lsn intervalToLsn, BlockingMultiResultSetConsumer consumer)
+    throws SQLException, InterruptedException {
     final String[] queries = new String[changeTables.length];
     final StatementPreparer[] preparers = new StatementPreparer[changeTables.length];
 
     int idx = 0;
-    for (ChangeTable changeTable: changeTables) {
+    for (SqlServerChangeTable changeTable : changeTables) {
       final String query = GET_ALL_CHANGES_FOR_TABLE.replace(STATEMENTS_PLACEHOLDER, changeTable.getCaptureInstance());
       queries[idx] = query;
       // If the table was added in the middle of queried buffer we need
       // to adjust from to the first LSN available
-      final Lsn fromLsn = changeTable.getStartLsn().compareTo(intervalFromLsn) > 0 ?
-        changeTable.getStartLsn() : intervalFromLsn;
+      final Lsn fromLsn = getFromLsn(changeTable, intervalFromLsn);
       LOGGER.trace("Getting changes for table {} in range[{}, {}]", changeTable, fromLsn, intervalToLsn);
       preparers[idx] = statement -> {
+        if (queryFetchSize > 0) {
+          statement.setFetchSize(queryFetchSize);
+        }
         statement.setBytes(1, fromLsn.getBinary());
         statement.setBytes(2, intervalToLsn.getBinary());
       };
@@ -133,6 +213,11 @@ public class SqlServerConnection extends JdbcConnection {
       idx++;
     }
     prepareQuery(queries, preparers, consumer);
+  }
+
+  private Lsn getFromLsn(SqlServerChangeTable changeTable, Lsn intervalFromLsn) throws SQLException {
+    Lsn fromLsn = changeTable.getStartLsn().compareTo(intervalFromLsn) > 0 ? changeTable.getStartLsn() : intervalFromLsn;
+    return fromLsn.getBinary() != null ? fromLsn : getMinLsn(changeTable.getCaptureInstance());
   }
 
   /**
@@ -157,11 +242,15 @@ public class SqlServerConnection extends JdbcConnection {
    * Map a commit LSN to a point in time when the commit happened.
    *
    * @param lsn - LSN of the commit
-   * @return time when the commit was recorded into the database log
+   * @return time when the commit was recorded into the database log or the
+   *         current time, depending on the setting for the "source timestamp
+   *         mode" option
    * @throws SQLException
    */
   public Instant timestampOfLsn(Lsn lsn) throws SQLException {
-    final String query = LSN_TO_TIMESTAMP;
+    if (SourceTimestampMode.PROCESSING.equals(sourceTimestampMode)) {
+      return clock.currentTime();
+    }
 
     if (lsn.getBinary() == null) {
       return null;
@@ -172,17 +261,31 @@ public class SqlServerConnection extends JdbcConnection {
       return cachedInstant;
     }
 
-    return prepareQueryAndMap(query, statement -> {
+    return prepareQueryAndMap(lsnToTimestamp, statement -> {
       statement.setBytes(1, lsn.getBinary());
     }, singleResultMapper(rs -> {
       final Timestamp ts = rs.getTimestamp(1);
-      final Instant ret = (ts == null) ? null : ts.toInstant();
+      Instant ret = (ts == null) ? null : normalize(ts);
       LOGGER.trace("Timestamp of lsn {} is {}", lsn, ret);
       if (ret != null) {
         lsnToInstantCache.put(lsn, ret);
       }
       return ret;
     }, "LSN to timestamp query must return exactly one value"));
+  }
+
+  private Instant normalize(Timestamp timestamp) {
+    Instant instant = timestamp.toInstant();
+
+    // in case the incoming timestamp was not based on UTC, shift it as per the
+    // configured timezone which must match the value used by the database
+    if (!transactionTimezone.getId().equals("UTC")) {
+      instant = instant.atZone(transactionTimezone)
+        .toLocalDateTime()
+        .toInstant(ZoneOffset.UTC);
+    }
+
+    return instant;
   }
 
   /**
@@ -200,21 +303,6 @@ public class SqlServerConnection extends JdbcConnection {
     return tableId.schema() + '_' + tableId.table();
   }
 
-  private <T> ResultSetMapper<T> singleResultMapper(ResultSetExtractor<T> extractor, String error) throws SQLException {
-    return (rs) -> {
-      if (rs.next()) {
-        final T ret = extractor.apply(rs);
-        if (!rs.next()) {
-          return ret;
-        }
-      }
-      throw new IllegalStateException(error);
-    };
-  }
-
-  /**
-   * Class for CDC enabled table.
-   */
   public static class CdcEnabledTable {
     private final String tableId;
     private final String captureName;
@@ -229,35 +317,37 @@ public class SqlServerConnection extends JdbcConnection {
     public String getTableId() {
       return tableId;
     }
+
     public String getCaptureName() {
       return captureName;
     }
+
     public Lsn getFromLsn() {
       return fromLsn;
     }
   }
 
-  public Set<ChangeTable> listOfChangeTables() throws SQLException {
+  public Set<SqlServerChangeTable> listOfChangeTables() throws SQLException {
     final String query = GET_LIST_OF_CDC_ENABLED_TABLES;
 
     return queryAndMap(query, rs -> {
-      final Set<ChangeTable> changeTables = new HashSet<>();
+      final Set<SqlServerChangeTable> changeTables = new HashSet<>();
       while (rs.next()) {
         changeTables.add(
-          new ChangeTable(
+          new SqlServerChangeTable(
             new TableId(realDatabaseName, rs.getString(1), rs.getString(2)),
             rs.getString(3),
             rs.getInt(4),
             Lsn.valueOf(rs.getBytes(6)),
-            Lsn.valueOf(rs.getBytes(7))
-          )
-        );
+            Lsn.valueOf(rs.getBytes(7)),
+            Arrays.asList(BRACKET_PATTERN.matcher(Optional.ofNullable(rs.getString(15)).orElse(""))
+                            .replaceAll("").split(", "))));
       }
       return changeTables;
     });
   }
 
-  public Set<ChangeTable> listOfNewChangeTables(Lsn fromLsn, Lsn toLsn) throws SQLException {
+  public Set<SqlServerChangeTable> listOfNewChangeTables(Lsn fromLsn, Lsn toLsn) throws SQLException {
     final String query = GET_LIST_OF_NEW_CDC_ENABLED_TABLES;
 
     return prepareQueryAndMap(query,
@@ -266,21 +356,19 @@ public class SqlServerConnection extends JdbcConnection {
                                 ps.setBytes(2, toLsn.getBinary());
                               },
                               rs -> {
-                                final Set<ChangeTable> changeTables = new HashSet<>();
+                                final Set<SqlServerChangeTable> changeTables = new HashSet<>();
                                 while (rs.next()) {
-                                  changeTables.add(new ChangeTable(
+                                  changeTables.add(new SqlServerChangeTable(
                                     rs.getString(4),
                                     rs.getInt(1),
                                     Lsn.valueOf(rs.getBytes(5)),
-                                    Lsn.valueOf(rs.getBytes(6))
-                                  ));
+                                    Lsn.valueOf(rs.getBytes(6))));
                                 }
                                 return changeTables;
-                              }
-    );
+                              });
   }
 
-  public Table getTableSchemaFromTable(ChangeTable changeTable) throws SQLException {
+  public Table getTableSchemaFromTable(SqlServerChangeTable changeTable) throws SQLException {
     final DatabaseMetaData metadata = connection().getMetaData();
 
     List<Column> columns = new ArrayList<>();
@@ -288,14 +376,18 @@ public class SqlServerConnection extends JdbcConnection {
       realDatabaseName,
       changeTable.getSourceTableId().schema(),
       changeTable.getSourceTableId().table(),
-      null)
-    ) {
+      null)) {
       while (rs.next()) {
-        readTableColumn(rs, changeTable.getSourceTableId(), null).ifPresent(ce -> columns.add(ce.create()));
+        readTableColumn(rs, changeTable.getSourceTableId(), null).ifPresent(ce -> {
+          // Filter out columns not included in the change table.
+          if (changeTable.getCapturedColumns().contains(ce.name())) {
+            columns.add(ce.create());
+          }
+        });
       }
     }
 
-    final List<String> pkColumnNames = readPrimaryKeyNames(metadata, changeTable.getSourceTableId());
+    final List<String> pkColumnNames = readPrimaryKeyOrUniqueIndexNames(metadata, changeTable.getSourceTableId());
     Collections.sort(columns);
     return Table.editor()
       .tableId(changeTable.getSourceTableId())
@@ -304,7 +396,7 @@ public class SqlServerConnection extends JdbcConnection {
       .create();
   }
 
-  public Table getTableSchemaFromChangeTable(ChangeTable changeTable) throws SQLException {
+  public Table getTableSchemaFromChangeTable(SqlServerChangeTable changeTable) throws SQLException {
     final DatabaseMetaData metadata = connection().getMetaData();
     final TableId changeTableId = changeTable.getChangeTableId();
 
@@ -316,8 +408,7 @@ public class SqlServerConnection extends JdbcConnection {
     }
 
     // The first 5 columns and the last column of the change table are CDC metadata
-    final List<Column> columns = columnEditors.subList(CHANGE_TABLE_DATA_COLUMN_OFFSET, columnEditors.size() - 1)
-      .stream()
+    final List<Column> columns = columnEditors.subList(CHANGE_TABLE_DATA_COLUMN_OFFSET, columnEditors.size() - 1).stream()
       .map(c -> c.position(c.position() - CHANGE_TABLE_DATA_COLUMN_OFFSET).create())
       .collect(Collectors.toList());
 
@@ -335,12 +426,6 @@ public class SqlServerConnection extends JdbcConnection {
       .create();
   }
 
-  public synchronized void rollback() throws SQLException {
-    if (isConnected()) {
-      connection().rollback();
-    }
-  }
-
   public String getNameOfChangeTable(String captureName) {
     return captureName + "_CT";
   }
@@ -349,12 +434,73 @@ public class SqlServerConnection extends JdbcConnection {
     return realDatabaseName;
   }
 
-  private  String retrieveRealDatabaseName() {
+  private ZoneId retrieveTransactionTimezone(boolean supportsAtTimeZone) {
+    final String serverTimezoneConfig = config().getString(SERVER_TIMEZONE_PROP_NAME);
+
+    if (supportsAtTimeZone) {
+      if (serverTimezoneConfig != null) {
+        LOGGER.warn("The '{}' option should not be specified with SQL Server 2016 and newer", SERVER_TIMEZONE_PROP_NAME);
+      }
+    }
+    else {
+      if (serverTimezoneConfig == null) {
+        LOGGER.warn(
+          "The '{}' option should be specified to avoid incorrect timestamp values in case of different timezones between the database server and this connector's JVM.",
+          SERVER_TIMEZONE_PROP_NAME);
+      }
+    }
+
+    // Assuming UTC to be used for the ts_ms TIMESTAMP column
+    // In case AT TIME ZONE is supported, UTC is what we'll request;
+    // Otherwise, UTC is as good as any other guess
+    return serverTimezoneConfig == null ? ZoneId.of("UTC") : ZoneId.of(serverTimezoneConfig, ZoneId.SHORT_IDS);
+  }
+
+  private String retrieveRealDatabaseName() {
     try {
-      return queryAndMap(GET_DATABASE_NAME,
-                         singleResultMapper(rs -> rs.getString(1), "Could not retrieve database name"));
-    } catch (SQLException e) {
+      return queryAndMap(
+        GET_DATABASE_NAME,
+        singleResultMapper(rs -> rs.getString(1), "Could not retrieve database name"));
+    }
+    catch (SQLException e) {
       throw new RuntimeException("Couldn't obtain database name", e);
     }
+  }
+
+  /**
+   * SELECT ... AT TIME ZONE only works on SQL Server 2016 and newer.
+   */
+  private boolean supportsAtTimeZone() {
+    try {
+      // Always expect the support if database is not standalone SQL Server, e.g. Azure
+      return getSqlServerVersion().orElse(Integer.MAX_VALUE) > 2016;
+    }
+    catch (Exception e) {
+      LOGGER.error("Couldn't obtain database server version; assuming 'AT TIME ZONE' is not supported.", e);
+      return false;
+    }
+  }
+
+  private Optional<Integer> getSqlServerVersion() {
+    try {
+      // As per https://www.mssqltips.com/sqlservertip/1140/how-to-tell-what-sql-server-version-you-are-running/
+      // Always beginning with 'Microsoft SQL Server NNNN' but only in case SQL Server is standalone
+      String version = queryAndMap(
+        SQL_SERVER_VERSION,
+        singleResultMapper(rs -> rs.getString(1), "Could not obtain SQL Server version"));
+      if (!version.startsWith("Microsoft SQL Server ")) {
+        return Optional.empty();
+      }
+      return Optional.of(Integer.valueOf(version.substring(21, 25)));
+    }
+    catch (Exception e) {
+      throw new RuntimeException("Couldn't obtain database server version", e);
+    }
+  }
+
+  @Override
+  protected Optional<Object> getDefaultValue(Column column, String defaultValue) {
+    return defaultValueConverter
+      .parseDefaultValue(column, defaultValue);
   }
 }


### PR DESCRIPTION
Upgrade the debezium version to 1.3.1.Final. Currently we use 0.9.5.Final which is outdated.
This PR mainly copies and fixes checkstyle issues in the debezium classes: MySQLConnectorConfig, MySqlJdbcContext, MySqlValueConverters, and SqlServerConnections corresponding to version 1.3.1.Final. This was done for 0.9.5.Final version in these PRs - #35 and #38. 