### PR TITLE
Override the describeTable method with schema parameter for SQL server source.

### DIFF
--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableRegistry.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerTableRegistry.java
@@ -99,6 +99,13 @@ public class SqlServerTableRegistry implements TableRegistry {
   }
 
   @Override
+  public TableDetail describeTable(String database, String schema, String table)
+    throws TableNotFoundException, IOException {
+    // TODO CDAP-17477 Ignore schema currently since its fetch from metadata in sql server
+    return describeTable(database, table);
+  }
+
+  @Override
   public TableDetail describeTable(String db, String table) throws TableNotFoundException, IOException {
     try (Connection connection = DriverManager.getConnection(jdbcUrl)) {
       List<Problem> missingFeatures = new ArrayList<>();


### PR DESCRIPTION
The default implementation provided by the interface is no-op. We need to delegate the call with schema to the existing describeTable impl.