### PR TITLE
CDAP-17472 Make consumer id optional for mysql plugin.

### DIFF
--- a/mysql-delta-plugins/docs/mysql-cdcSource.md
+++ b/mysql-delta-plugins/docs/mysql-cdcSource.md
@@ -58,9 +58,9 @@ Plugin Properties
 
 **Port:** Port to use to connect to the MySQL server.
 
-**Consumer ID:** An unique numeric ID to identify this origin as an event consumer. This number cannot be the same as 
-another Delta Replicator that is reading from the server, and it cannot be the same as the server-id for any MySQL 
-slave that is replicating from the server.
+**Consumer ID:** Optional unique numeric ID to identify this origin as an event consumer. This number cannot be the 
+same as another Delta Replicator that is reading from the server, and it cannot be the same as the server-id for any
+ MySQL slave that is replicating from the server. By default, random number will be used. 
 
 **Server Timezone:** Timezone of the MySQL server. This is used when converting dates into timestamps.
 

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
@@ -41,10 +41,11 @@ public class MySqlConfig extends PluginConfig {
   @Description("Password to use to connect to the MySQL server.")
   private String password;
 
-  @Description("A unique numeric ID to identify this origin as an event consumer. When replication pipeline is " +
-    "configured with multiple instances, each instance gets unique consumer id by adding instance id to " +
-    "this supplied consumer id.")
-  private int consumerID;
+  @Nullable
+  @Description("An optional unique numeric ID to identify this origin as an event consumer. When replication " +
+    "pipeline is configured with multiple instances, each instance gets unique consumer id by adding instance id to " +
+    "this supplied consumer id. By default, random number will be used.")
+  private Integer consumerID;
 
   @Description("Database to replicate data from.")
   private String database;
@@ -83,7 +84,8 @@ public class MySqlConfig extends PluginConfig {
     return password;
   }
 
-  public int getConsumerID() {
+  @Nullable
+  public Integer getConsumerID() {
     return consumerID;
   }
 

--- a/mysql-delta-plugins/widgets/mysql-cdcSource.json
+++ b/mysql-delta-plugins/widgets/mysql-cdcSource.json
@@ -21,11 +21,6 @@
           }
         },
         {
-          "name": "consumerID",
-          "label": "Consumer ID",
-          "widget-type": "textbox"
-        },
-        {
           "name": "jdbcPluginName",
           "label": "JDBC Plugin Name",
           "widget-type": "plugin-list",
@@ -58,6 +53,11 @@
     {
       "label": "Advanced",
       "properties": [
+        {
+          "name": "consumerID",
+          "label": "Consumer ID",
+          "widget-type": "textbox"
+        },
         {
           "name": "serverTimezone",
           "label": "Server Timezone",


### PR DESCRIPTION
When not provided, debezium picks random value for `database.server.id`. - Reference: https://debezium.io/documentation/reference/1.3/connectors/mysql.html