### PR TITLE
CDAP-16735 fix DBSchemaHistory

### DIFF
--- a/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/DBSchemaHistory.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/DBSchemaHistory.java
@@ -37,9 +37,20 @@ public class DBSchemaHistory extends AbstractDatabaseHistory {
   private static final String KEY = "history";
   // Hacky, fix when usage of EmbeddedEngine is replaced
   public static DeltaRuntimeContext deltaRuntimeContext;
-  private final DocumentWriter writer = DocumentWriter.defaultWriter();
-  private final DocumentReader reader = DocumentReader.defaultReader();
+  private static final DocumentWriter writer = DocumentWriter.defaultWriter();
+  private static final DocumentReader reader = DocumentReader.defaultReader();
 
+  /**
+   * Restart the DB schema history from certain {@link HistoryRecord HistoryRecord} specified by the parameter
+   * @param index the position of the {@link HistoryRecord HistoryRecord} to restart from in the history list. A
+   *              negative value will wipe out all the history
+   */
+  public static void restartFrom(int index) throws IOException {
+    if (index < 0) {
+      wipeHistory();
+    }
+    storeHistory(getHistory().subList(0, index + 1));
+  }
   public static void wipeHistory() throws IOException {
     deltaRuntimeContext.putState(KEY, new byte[] { });
   }
@@ -48,6 +59,10 @@ public class DBSchemaHistory extends AbstractDatabaseHistory {
   protected synchronized void storeRecord(HistoryRecord record) throws DatabaseHistoryException {
     List<HistoryRecord> history = getHistory();
     history.add(record);
+    storeHistory(history);
+  }
+
+  private static void storeHistory(List<HistoryRecord> history) {
     String historyStr = history.stream().map(r -> {
       try {
         return writer.write(r.document());
@@ -84,7 +99,7 @@ public class DBSchemaHistory extends AbstractDatabaseHistory {
   }
 
   // TODO: cache history, should only have to read once
-  private List<HistoryRecord> getHistory() {
+  private static List<HistoryRecord> getHistory() {
     List<HistoryRecord> history = new ArrayList<>();
     try {
       byte[] historyBytes = deltaRuntimeContext.getState(KEY);

--- a/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/DBSchemaHistory.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/DBSchemaHistory.java
@@ -48,6 +48,7 @@ public class DBSchemaHistory extends AbstractDatabaseHistory {
   public static void restartFrom(int index) throws IOException {
     if (index < 0) {
       wipeHistory();
+      return;
     }
     storeHistory(getHistory().subList(0, index + 1));
   }

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
@@ -133,7 +133,6 @@ public class MySqlEventReader implements EventReader {
       throw new RuntimeException("Unable to reset the schema history at start of replication.", e);
     }
 
-
     MySqlValueConverters mySqlValueConverters = getValueConverters(mysqlConf);
     DdlParser ddlParser = new MySqlAntlrDdlParser(mySqlValueConverters, tableId -> true);
 

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
@@ -17,7 +17,6 @@
 package io.cdap.delta.mysql;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.cdap.delta.api.DeltaFailureException;
 import io.cdap.delta.api.DeltaSourceContext;
 import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.EventReader;
@@ -39,6 +38,7 @@ import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Tables;
 import io.debezium.relational.ddl.DdlParser;
+import io.debezium.relational.history.HistoryRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +59,8 @@ import java.util.stream.Collectors;
  */
 public class MySqlEventReader implements EventReader {
   public static final Logger LOG = LoggerFactory.getLogger(MySqlEventReader.class);
+
+  static final String SCHEMA_HISTORY_INDEX = "schema.history";
   private final MySqlConfig config;
   private final EventEmitter emitter;
   private final ExecutorService executorService;
@@ -119,20 +121,18 @@ public class MySqlEventReader implements EventReader {
       .build();
     MySqlConnectorConfig mysqlConf = new MySqlConnectorConfig(debeziumConf);
     DBSchemaHistory.deltaRuntimeContext = context;
-    /*
-       this is required in scenarios where the source is able to emit the starting DDL events during snapshotting,
-       but the target is unable to apply them. In that case, this reader will be created again, but it won't re-emit
-       those DDL events unless the DB history is wiped. This only fixes handling of DDL errors that
-       happen during the initial snapshot.
-        TODO: (CDAP-16735) fix this more comprehensively
+    /**
+     * DBSchemaHistory stores the historical DDL changes. Each time Debezium detects a DDL change in binlog, it will
+     * store a {@link HistoryRecord History Record} to DBSchemaHistory, in case of a failure or on purpose stop,
+     * It knows where to restart from.
      */
-    if (offset.get().isEmpty()) {
-      try {
-        DBSchemaHistory.wipeHistory();
-      } catch (IOException e) {
-        throw new RuntimeException("Unable to wipe schema history at start of replication.", e);
-      }
+    int schemaHistoryIndex = Integer.parseInt(state.getOrDefault(SCHEMA_HISTORY_INDEX, "-1"));
+    try {
+      DBSchemaHistory.restartFrom(schemaHistoryIndex);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to reset the schema history at start of replication.", e);
     }
+
 
     MySqlValueConverters mySqlValueConverters = getValueConverters(mysqlConf);
     DdlParser ddlParser = new MySqlAntlrDdlParser(mySqlValueConverters, tableId -> true);
@@ -144,7 +144,7 @@ public class MySqlEventReader implements EventReader {
       engine = EmbeddedEngine.create()
         .using(debeziumConf)
         .notifying(new MySqlRecordConsumer(context, emitter, ddlParser, mySqlValueConverters,
-                                           new Tables(), sourceTableMap))
+                                           new Tables(), sourceTableMap, schemaHistoryIndex))
         .using(new NotifyingCompletionCallback(context))
         .build();
       executorService.submit(engine);

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
@@ -130,11 +130,6 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
     boolean readAllTables = sourceTableMap.isEmpty();
 
     String ddl = val.get("ddl");
-    if (ddl != null) {
-      // ddl and schema HistoryRecord is one-one mapping
-      schemaHistoryIndex++;
-    }
-
     Map<String, String> deltaOffset = generateCdapOffsets(sourceRecord);
     try {
       if (ddl != null) {

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
@@ -153,7 +153,7 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
 
   private void handleDML(StructuredRecord source, StructuredRecord val, Map<String, String> deltaOffset,
                          boolean isSnapshot, boolean readAllTables) throws InterruptedException {
-    deltaOffset.put(MySqlEventReader.SCHEMA_HISTORY_INDEX, String.valueOf(++schemaHistoryIndex));
+    deltaOffset.put(MySqlEventReader.SCHEMA_HISTORY_INDEX, String.valueOf(schemaHistoryIndex));
     String databaseName = source.get("db");
     String tableName = source.get("table");
     SourceTable sourceTable = getSourceTable(databaseName, tableName);


### PR DESCRIPTION
DBSchemaHistory stores a list of HistoryRecords, each History record corresponds to a DDL change.