### PR TITLE
remove macro for password of delta source

### DIFF
--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConfig.java
@@ -17,7 +17,6 @@
 package io.cdap.delta.mysql;
 
 import io.cdap.cdap.api.annotation.Description;
-import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.plugin.PluginConfig;
 
 import java.util.Properties;
@@ -37,7 +36,6 @@ public class MySqlConfig extends PluginConfig {
     "to the MySQL server will be of the form 'user_name'@'%' where user_name is this field.")
   private String user;
 
-  @Macro
   @Description("Password to use to connect to the MySQL server.")
   private String password;
 

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConfig.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConfig.java
@@ -17,7 +17,6 @@
 package io.cdap.delta.sqlserver;
 
 import io.cdap.cdap.api.annotation.Description;
-import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.plugin.PluginConfig;
 
 import javax.annotation.Nullable;
@@ -36,7 +35,6 @@ public class SqlServerConfig extends PluginConfig {
   @Description("Username to use to connect to the SqlServer.")
   private String user;
 
-  @Macro
   @Description("Password to use to connect to the SqlServer.")
   private String password;
 


### PR DESCRIPTION
Why:

those password are used to connect to source database from CDAP in data plane , thus cannot support Macro.