### PR TITLE
Fix Schema History

### DIFF
--- a/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/DBSchemaHistory.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/DBSchemaHistory.java
@@ -37,21 +37,9 @@ public class DBSchemaHistory extends AbstractDatabaseHistory {
   private static final String KEY = "history";
   // Hacky, fix when usage of EmbeddedEngine is replaced
   public static DeltaRuntimeContext deltaRuntimeContext;
-  private static final DocumentWriter writer = DocumentWriter.defaultWriter();
-  private static final DocumentReader reader = DocumentReader.defaultReader();
+  private final DocumentWriter writer = DocumentWriter.defaultWriter();
+  private final DocumentReader reader = DocumentReader.defaultReader();
 
-  /**
-   * Restart the DB schema history from certain {@link HistoryRecord HistoryRecord} specified by the parameter
-   * @param index the position of the {@link HistoryRecord HistoryRecord} to restart from in the history list. A
-   *              negative value will wipe out all the history
-   */
-  public static void restartFrom(int index) throws IOException {
-    if (index < 0) {
-      wipeHistory();
-      return;
-    }
-    storeHistory(getHistory().subList(0, index + 1));
-  }
   public static void wipeHistory() throws IOException {
     deltaRuntimeContext.putState(KEY, new byte[] { });
   }
@@ -60,10 +48,6 @@ public class DBSchemaHistory extends AbstractDatabaseHistory {
   protected synchronized void storeRecord(HistoryRecord record) throws DatabaseHistoryException {
     List<HistoryRecord> history = getHistory();
     history.add(record);
-    storeHistory(history);
-  }
-
-  private static void storeHistory(List<HistoryRecord> history) {
     String historyStr = history.stream().map(r -> {
       try {
         return writer.write(r.document());
@@ -100,7 +84,7 @@ public class DBSchemaHistory extends AbstractDatabaseHistory {
   }
 
   // TODO: cache history, should only have to read once
-  private static List<HistoryRecord> getHistory() {
+  private List<HistoryRecord> getHistory() {
     List<HistoryRecord> history = new ArrayList<>();
     try {
       byte[] historyBytes = deltaRuntimeContext.getState(KEY);

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
@@ -17,6 +17,7 @@
 package io.cdap.delta.mysql;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.cdap.delta.api.DeltaFailureException;
 import io.cdap.delta.api.DeltaSourceContext;
 import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.EventReader;
@@ -38,7 +39,6 @@ import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Tables;
 import io.debezium.relational.ddl.DdlParser;
-import io.debezium.relational.history.HistoryRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,8 +59,6 @@ import java.util.stream.Collectors;
  */
 public class MySqlEventReader implements EventReader {
   public static final Logger LOG = LoggerFactory.getLogger(MySqlEventReader.class);
-
-  static final String SCHEMA_HISTORY_INDEX = "schema.history";
   private final MySqlConfig config;
   private final EventEmitter emitter;
   private final ExecutorService executorService;
@@ -126,16 +124,19 @@ public class MySqlEventReader implements EventReader {
     Configuration debeziumConf = configBuilder.build();
     MySqlConnectorConfig mysqlConf = new MySqlConnectorConfig(debeziumConf);
     DBSchemaHistory.deltaRuntimeContext = context;
-    /**
-     * DBSchemaHistory stores the historical DDL changes. Each time Debezium detects a DDL change in binlog, it will
-     * store a {@link HistoryRecord History Record} to DBSchemaHistory, in case of a failure or on purpose stop,
-     * It knows where to restart from.
+    /*
+       this is required in scenarios where the source is able to emit the starting DDL events during snapshotting,
+       but the target is unable to apply them. In that case, this reader will be created again, but it won't re-emit
+       those DDL events unless the DB history is wiped. This only fixes handling of DDL errors that
+       happen during the initial snapshot.
+        TODO: (CDAP-16735) fix this more comprehensively
      */
-    int schemaHistoryIndex = Integer.parseInt(state.getOrDefault(SCHEMA_HISTORY_INDEX, "-1"));
-    try {
-      DBSchemaHistory.restartFrom(schemaHistoryIndex);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to reset the schema history at start of replication.", e);
+    if (offset.get().isEmpty()) {
+      try {
+        DBSchemaHistory.wipeHistory();
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to wipe schema history at start of replication.", e);
+      }
     }
 
     MySqlValueConverters mySqlValueConverters = getValueConverters(mysqlConf);
@@ -148,7 +149,7 @@ public class MySqlEventReader implements EventReader {
       engine = EmbeddedEngine.create()
         .using(debeziumConf)
         .notifying(new MySqlRecordConsumer(context, emitter, ddlParser, mySqlValueConverters,
-                                           new Tables(), sourceTableMap, schemaHistoryIndex))
+                                           new Tables(), sourceTableMap))
         .using(new NotifyingCompletionCallback(context))
         .build();
       executorService.submit(engine);

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
@@ -126,7 +126,7 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
       // This should not happen, 'source' is a mandatory field in sourceRecord from debezium
       return;
     }
-    boolean isSnapshot = Boolean.TRUE.equals(source.get(MySqlConstantOffsetBackingStore.SNAPSHOT));
+    boolean isSnapshot = Boolean.TRUE.equals(deltaOffset.get(MySqlConstantOffsetBackingStore.SNAPSHOT));
     // If the map is empty, we should read all DDL/DML events and columns of all tables
     boolean readAllTables = sourceTableMap.isEmpty();
 

--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlRecordConsumer.java
@@ -56,18 +56,16 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
   private final MySqlValueConverters mySqlValueConverters;
   private final Tables tables;
   private final Map<String, SourceTable> sourceTableMap;
-  private int schemaHistoryIndex;
 
   public MySqlRecordConsumer(DeltaSourceContext context, EventEmitter emitter,
                              DdlParser ddlParser, MySqlValueConverters mySqlValueConverters,
-                             Tables tables, Map<String, SourceTable> sourceTableMap, int schemaHistoryIndex) {
+                             Tables tables, Map<String, SourceTable> sourceTableMap) {
     this.context = context;
     this.emitter = emitter;
     this.ddlParser = ddlParser;
     this.mySqlValueConverters = mySqlValueConverters;
     this.tables = tables;
     this.sourceTableMap = sourceTableMap;
-    this.schemaHistoryIndex = schemaHistoryIndex;
   }
 
   @Override
@@ -118,8 +116,11 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
       return;
     }
 
+    Map<String, String> deltaOffset = generateCdapOffsets(sourceRecord);
+    Offset recordOffset = new Offset(deltaOffset);
 
     StructuredRecord val = Records.convert((Struct) sourceRecord.value());
+    String ddl = val.get("ddl");
     StructuredRecord source = val.get("source");
     if (source == null) {
       // This should not happen, 'source' is a mandatory field in sourceRecord from debezium
@@ -129,11 +130,9 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
     // If the map is empty, we should read all DDL/DML events and columns of all tables
     boolean readAllTables = sourceTableMap.isEmpty();
 
-    String ddl = val.get("ddl");
-    Map<String, String> deltaOffset = generateCdapOffsets(sourceRecord);
     try {
       if (ddl != null) {
-        handleDDL(ddl, deltaOffset, isSnapshot, readAllTables);
+        handleDDL(ddl, recordOffset, isSnapshot, readAllTables);
         return;
       }
 
@@ -144,16 +143,15 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
         return;
       }
 
-      handleDML(source, val, deltaOffset, isSnapshot, readAllTables);
+      handleDML(source, val, recordOffset, isSnapshot, readAllTables);
     } catch (InterruptedException e) {
       // happens when the event reader is stopped. throwing this exception tells Debezium to stop right away
       throw new StopConnectorException("Interrupted while emitting event.");
     }
   }
 
-  private void handleDML(StructuredRecord source, StructuredRecord val, Map<String, String> deltaOffset,
+  private void handleDML(StructuredRecord source, StructuredRecord val, Offset recordOffset,
                          boolean isSnapshot, boolean readAllTables) throws InterruptedException {
-    deltaOffset.put(MySqlEventReader.SCHEMA_HISTORY_INDEX, String.valueOf(schemaHistoryIndex));
     String databaseName = source.get("db");
     String tableName = source.get("table");
     SourceTable sourceTable = getSourceTable(databaseName, tableName);
@@ -200,7 +198,7 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
 
     Long ingestTime = val.get("ts_ms");
     DMLEvent.Builder builder = DMLEvent.builder()
-      .setOffset(new Offset(deltaOffset))
+      .setOffset(recordOffset)
       .setOperationType(op)
       .setDatabaseName(databaseName)
       .setTableName(tableName)
@@ -218,9 +216,8 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
     }
   }
 
-  private void handleDDL(String ddlStatement, Map<String, String> deltaOffset,
+  private void handleDDL(String ddlStatement, Offset recordOffset,
                          boolean isSnapshot, boolean readAllTables) throws InterruptedException {
-    deltaOffset.put(MySqlEventReader.SCHEMA_HISTORY_INDEX, String.valueOf(++schemaHistoryIndex));
     ddlParser.getDdlChanges().reset();
     ddlParser.parse(ddlStatement, tables);
     AtomicReference<InterruptedException> interrupted = new AtomicReference<>();
@@ -230,7 +227,7 @@ public class MySqlRecordConsumer implements Consumer<SourceRecord> {
       }
       for (DdlParserListener.Event event : events) {
         DDLEvent.Builder builder = DDLEvent.builder()
-          .setOffset(new Offset(deltaOffset))
+          .setOffset(recordOffset)
           .setDatabaseName(databaseName)
           .setSnapshot(isSnapshot);
         DDLEvent ddlEvent = null;


### PR DESCRIPTION
According to  Debezium's document : https://debezium.io/documentation/reference/0.10/connectors/mysql.html#database-schema-history

`It also records in a separate database history Kafka topic all of the DDL statements along with the position in the binlog where each DDL statement appeared.`

History Record is associate with the DDL position:
https://github.com/debezium/debezium/blob/73003e9b7cab7671b64c314c5c282acce4952737/debezium-core/src/main/java/io/debezium/relational/history/HistoryRecord.java#L79 

And Debezium will ignore those history record that is later than the resuming point :
https://github.com/debezium/debezium/blob/73003e9b7cab7671b64c314c5c282acce4952737/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java#L84

So we don't need to bother filtering out history record that are later than resuming point and instead we need to make sure we don't store duplicate history record if we resume from a point that is earlier than the latest history record we've serialized.

The change of this fix is:

1. revert the changes of https://github.com/data-integrations/database-delta-plugins/pull/125
2. when storing a history record, check whether it's earlier than the latest history record we've serialized. if that's the case, skip it.