### PR TITLE
CDAP-17584 clear the snapshotting table list when resume from middle of the snapshotting

### DIFF
--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerEventReader.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerEventReader.java
@@ -135,6 +135,7 @@ public class SqlServerEventReader implements EventReader {
      * will resume from beginning.
      */
     if (offset.get().isEmpty() || !"true".equalsIgnoreCase(isSnapshotCompleted)) {
+      snapshotTables.clear();
       try {
         DBSchemaHistory.wipeHistory();
       } catch (IOException e) {

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerEventReader.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerEventReader.java
@@ -125,9 +125,9 @@ public class SqlServerEventReader implements EventReader {
 
     DBSchemaHistory.deltaRuntimeContext = context;
 
-    String snapshotTablesStr = state.get(SqlServerOffset.SNAPSHOT_TABLES);
-    Set<String> snapshotTables = Strings.isNullOrEmpty(snapshotTablesStr) ? new HashSet<>() :
-      new HashSet<>(Arrays.asList(snapshotTablesStr.split(SqlServerOffset.DELIMITER)));
+    String ddlEventSentStr = state.get(SqlServerOffset.DDL_EVENT_SENT);
+    Set<String> ddlEventSent = Strings.isNullOrEmpty(ddlEventSentStr) ? new HashSet<>() :
+      new HashSet<>(Arrays.asList(ddlEventSentStr.split(SqlServerOffset.DELIMITER)));
 
     /*
      * All snapshot events or schema history record have same position/offset
@@ -135,7 +135,7 @@ public class SqlServerEventReader implements EventReader {
      * will resume from beginning.
      */
     if (offset.get().isEmpty() || !"true".equalsIgnoreCase(isSnapshotCompleted)) {
-      snapshotTables.clear();
+      ddlEventSent.clear();
       try {
         DBSchemaHistory.wipeHistory();
       } catch (IOException e) {
@@ -150,7 +150,7 @@ public class SqlServerEventReader implements EventReader {
       LOG.info("creating new EmbeddedEngine...");
       // Create the engine with this configuration ...
       engine = EmbeddedEngine.create()
-        .notifying(new SqlServerRecordConsumer(context, emitter, databaseName, snapshotTables, sourceTableMap, offset))
+        .notifying(new SqlServerRecordConsumer(context, emitter, databaseName, ddlEventSent, sourceTableMap, offset))
         .using(debeziumConf)
         .using(new NotifyingCompletionCallback(context))
         .build();

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
@@ -31,32 +31,32 @@ import java.util.Set;
  */
 public class SqlServerOffset {
   static final String DELIMITER = ",";
-  static final String SNAPSHOT_TABLES = "snapshot_tables";
+  static final String DDL_EVENT_SENT = "ddl_event_sent";
 
   private final String changeLsn;
   private final String commitLsn;
   private final Boolean isSnapshot;
   private final Boolean isSnapshotCompleted;
-  private Set<String> snapshotTables;
+  private Set<String> ddlEventSent;
 
   SqlServerOffset(Map<String, ?> properties) {
     this.changeLsn = (String) properties.get(SourceInfo.CHANGE_LSN_KEY);
     this.commitLsn = (String) properties.get(SourceInfo.COMMIT_LSN_KEY);
     this.isSnapshot = (Boolean) properties.get(SourceInfo.SNAPSHOT_KEY);
     this.isSnapshotCompleted = (Boolean) properties.get(SqlServerConstantOffsetBackingStore.SNAPSHOT_COMPLETED);
-    this.snapshotTables = new HashSet<>();
+    this.ddlEventSent = new HashSet<>();
   }
 
   boolean isSnapshot() {
     return Boolean.TRUE.equals(isSnapshot);
   }
 
-  void setSnapshotTables(Set<String> snapshotTables) {
-    this.snapshotTables = new HashSet<>(snapshotTables);
+  void setDdlEventSent(Set<String> ddlEventSent) {
+    this.ddlEventSent = new HashSet<>(ddlEventSent);
   }
 
   void addSnapshotTable(String table) {
-    snapshotTables.add(table);
+    ddlEventSent.add(table);
   }
 
   Offset getAsOffset() {
@@ -73,8 +73,8 @@ public class SqlServerOffset {
     if (isSnapshotCompleted != null) {
       deltaOffset.put(SqlServerConstantOffsetBackingStore.SNAPSHOT_COMPLETED, String.valueOf(isSnapshotCompleted));
     }
-    if (snapshotTables != null && !snapshotTables.isEmpty()) {
-      deltaOffset.put(SNAPSHOT_TABLES, String.join(DELIMITER, snapshotTables));
+    if (ddlEventSent != null && !ddlEventSent.isEmpty()) {
+      deltaOffset.put(DDL_EVENT_SENT, String.join(DELIMITER, ddlEventSent));
     }
 
     return new Offset(deltaOffset);
@@ -106,11 +106,11 @@ public class SqlServerOffset {
       && Objects.equals(commitLsn, that.commitLsn)
       && Objects.equals(isSnapshot, that.isSnapshot)
       && Objects.equals(isSnapshotCompleted, that.isSnapshotCompleted)
-      && Objects.equals(snapshotTables, that.snapshotTables);
+      && Objects.equals(ddlEventSent, that.ddlEventSent);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(changeLsn, commitLsn, isSnapshot, isSnapshotCompleted, snapshotTables);
+    return Objects.hash(changeLsn, commitLsn, isSnapshot, isSnapshotCompleted, ddlEventSent);
   }
 }

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
@@ -51,18 +51,19 @@ public class SqlServerRecordConsumer implements Consumer<SourceRecord> {
   private final EventEmitter emitter;
   // we need this since there is no way to get the db information from the source record
   private final String databaseName;
-  private final Set<String> snapshotTables;
+  // record tables that already had DDL events sent
+  private final Set<String> ddlEventSent;
   private final Map<String, SourceTable> sourceTableMap;
   private Offset latestOffset;
 
 
   SqlServerRecordConsumer(DeltaSourceContext context, EventEmitter emitter, String databaseName,
-                          Set<String> snapshotTables, Map<String, SourceTable> sourceTableMap,
+                          Set<String> ddlEventSent, Map<String, SourceTable> sourceTableMap,
     Offset latestOffset) {
     this.context = context;
     this.emitter = emitter;
     this.databaseName = databaseName;
-    this.snapshotTables = snapshotTables;
+    this.ddlEventSent = ddlEventSent;
     this.sourceTableMap = sourceTableMap;
     this.latestOffset = latestOffset;
   }
@@ -89,7 +90,7 @@ public class SqlServerRecordConsumer implements Consumer<SourceRecord> {
       return;
     }
 
-    sqlServerOffset.setSnapshotTables(snapshotTables);
+    sqlServerOffset.setDdlEventSent(ddlEventSent);
     boolean isSnapshot = sqlServerOffset.isSnapshot();
     latestOffset = sqlServerOffset.getAsOffset();
 
@@ -149,7 +150,7 @@ public class SqlServerRecordConsumer implements Consumer<SourceRecord> {
     Schema schema = value.getSchema();
     // send the ddl events only if we see the table at the first time
     // Note: the delta app itself have prevented adding CREATE_TABLE operation into DDL blacklist for all the tables.
-    if (!snapshotTables.contains(sourceTableId)) {
+    if (!ddlEventSent.contains(sourceTableId)) {
       StructuredRecord key = Records.convert((Struct) sourceRecord.key());
       List<Schema.Field> fields = key.getSchema().getFields();
       List<String> primaryFields = new ArrayList<>();
@@ -182,7 +183,7 @@ public class SqlServerRecordConsumer implements Consumer<SourceRecord> {
         // happens when the event reader is stopped. throwing this exception tells Debezium to stop right away
         throw new StopConnectorException("Interrupted while emitting an event.");
       }
-      snapshotTables.add(sourceTableId);
+      ddlEventSent.add(sourceTableId);
     }
 
     if (!readAllTables && sourceTable.getDmlBlacklist().contains(op)) {


### PR DESCRIPTION
issue:
If the replicator failed or resume from middle of snapshotting, Debezium will restart from the beginning of all the events, thus will have dup events in the target table.

solution:
In the offset we record what tables were created. And we emit DDL event for drop table and create table for that table if the table was not created.

So once replicator is resumed , we check whether snapshot is done, if not , we clear the list that records what tables were created. In this way all the previous partially snapshotted data will be dropped by drop table DDL. 

follow up :
created CDAP-17681 for enhancement.

