### PR TITLE
CDAP-17582 Allow passing the debezium connector configurations through runtime arguments.

### DIFF
--- a/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/RuntimeArguments.java
+++ b/delta-plugins-common/src/main/java/io/cdap/delta/plugin/common/RuntimeArguments.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.plugin.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for manipulating runtime arguments.
+ */
+public final class RuntimeArguments {
+  private RuntimeArguments() {
+  }
+
+  /**
+   * Identifies arguments with a given prefix, removes them from the arguments and adds new arguments back without
+   * the prefix. Arguments which do not start with the given prefix will be ignored.
+   *
+   * @param prefix prefix to look for in arguments
+   * @param arguments the runtime arguments
+   * @return a new map that contains the arguments without prefix
+   */
+  public static Map<String, String> extractPrefixed(String prefix, Map<String, String> arguments) {
+    Map<String, String> result = new HashMap<>();
+    for (Map.Entry<String, String> entry : arguments.entrySet()) {
+      if (entry.getKey().startsWith(prefix)) {
+        result.put(entry.getKey().substring(prefix.length()), entry.getValue());
+      }
+    }
+    return result;
+  }
+}

--- a/delta-plugins-common/src/test/java/io/cdap/delta/plugin/common/RuntimeArgumentsTest.java
+++ b/delta-plugins-common/src/test/java/io/cdap/delta/plugin/common/RuntimeArgumentsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.plugin.common;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * Test for RuntimeArguments.
+ */
+public class RuntimeArgumentsTest {
+
+  @Test
+  public void testRemovePrefix() {
+    Map<String, String> arguments = ImmutableMap.of("source.connector.database.host", "1.1.1.1",
+                                                    "source.connector.name", "somename",
+                                                    "somekey", "somevalue");
+    Map<String, String> expected = ImmutableMap.of("database.host", "1.1.1.1",
+                                                   "name", "somename");
+
+    Assert.assertEquals(expected, RuntimeArguments.extractPrefixed("source.connector.", arguments));
+  }
+}


### PR DESCRIPTION
JIRA: https://cdap.atlassian.net/browse/CDAP-17582

When starting pipeline user can provide the configurations for debezium in the form prefixed with `source.connector.`. 
Debezium requires jdbc properties to be prefixed by `database.`. So to configure JDBC properties for replication app, runtime argument will need to be prefixed with `source.connector.database.`.