### PR TITLE
Set the record offset (specifically 'snapshot' and 'snapshot_completed' fields) explicitly based on the incoming source record for the SQL server source.

### DIFF
--- a/sqlserver-delta-plugins/docs/sqlserver-cdcSource.md
+++ b/sqlserver-delta-plugins/docs/sqlserver-cdcSource.md
@@ -51,6 +51,13 @@ EXEC sys.sp_cdc_help_change_data_capture
 GO
 ```
 
+### Grant permission on user defined type
+If the tables to be replicated contain columns of user defined types, the table owner must grant EXECUTE permissions on
+the custom data types to the database user specified in the replication job.
+``````
+GRANT EXECUTE ON TYPE::YOUR_TYPE to YOUR_USER
+```
+
 Setting up JDBC Driver
 -----------
 If it is not already installed, instructions for installing the Microsoft SQL Server JDBC driver can be found on the 

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerOffset.java
@@ -37,26 +37,26 @@ public class SqlServerOffset {
   private final String commitLsn;
   private final Boolean isSnapshot;
   private final Boolean isSnapshotCompleted;
-  private Set<String> ddlEventSent;
+  private final Set<String> ddlEventSent;
 
-  SqlServerOffset(Map<String, ?> properties) {
+  SqlServerOffset(Map<String, ?> properties, Set<String> ddlEventSent) {
     this.changeLsn = (String) properties.get(SourceInfo.CHANGE_LSN_KEY);
     this.commitLsn = (String) properties.get(SourceInfo.COMMIT_LSN_KEY);
-    this.isSnapshot = (Boolean) properties.get(SourceInfo.SNAPSHOT_KEY);
-    this.isSnapshotCompleted = (Boolean) properties.get(SqlServerConstantOffsetBackingStore.SNAPSHOT_COMPLETED);
-    this.ddlEventSent = new HashSet<>();
+    if (properties.containsKey(SourceInfo.SNAPSHOT_KEY)) {
+      this.isSnapshot = (Boolean) properties.get(SourceInfo.SNAPSHOT_KEY);
+    } else {
+      this.isSnapshot = false;
+    }
+    if (properties.containsKey(SqlServerConstantOffsetBackingStore.SNAPSHOT_COMPLETED)) {
+      this.isSnapshotCompleted = (Boolean) properties.get(SqlServerConstantOffsetBackingStore.SNAPSHOT_COMPLETED);
+    } else {
+      this.isSnapshotCompleted = true;
+    }
+    this.ddlEventSent = ddlEventSent;
   }
 
   boolean isSnapshot() {
     return isSnapshot;
-  }
-
-  void setDdlEventSent(Set<String> ddlEventSent) {
-    this.ddlEventSent = new HashSet<>(ddlEventSent);
-  }
-
-  void addSnapshotTable(String table) {
-    ddlEventSent.add(table);
   }
 
   Offset getAsOffset() {


### PR DESCRIPTION
Also made `SqlServerOffset` class immutable. 

Following specific scenario was failing without the fix:
1. Replicate the source table containing 1 record.
2. Stop the replication pipeline.
3. Add more records to source table.
4. Start replication pipeline.

Pipeline generated DDL events (DROP and CREATE tables) again after step 4 because `ddlEventSent` field was not persisted at the end of step 1.