### PR TITLE
CDAP-17583 Assign unique id to the sql server connector so that in case of multiple executors each connector can fetch data in parallel.

### DIFF
--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlEventReader.java
@@ -49,6 +49,7 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -110,7 +111,7 @@ public class MySqlEventReader implements EventReader {
       .with("event", state.getOrDefault(MySqlConstantOffsetBackingStore.EVENT, ""))
       .with("gtids", state.getOrDefault(MySqlConstantOffsetBackingStore.GTID_SET, ""))
       /* begin connector properties */
-      .with("name", "delta")
+      .with("name", "delta" + UUID.randomUUID().toString().replace("-", ""))
       .with("database.hostname", config.getHost())
       .with("database.port", config.getPort())
       .with("database.user", config.getUser())

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerEventReader.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerEventReader.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -116,7 +117,7 @@ public class SqlServerEventReader implements EventReader {
       .with("snapshot", state.getOrDefault(SourceInfo.SNAPSHOT_KEY, ""))
       .with("snapshot_completed", isSnapshotCompleted)
       /* begin connector properties */
-      .with("name", "delta")
+      .with("name", "delta" + UUID.randomUUID().toString().replace("-", ""))
       .with("database.hostname", config.getHost())
       .with("database.port", config.getPort())
       .with("database.user", config.getUser())


### PR DESCRIPTION
Without this change only one sql server replicator worker instance will be able to fetch the data. With the fix all workers were working in parallel. 

![image](https://user-images.githubusercontent.com/5713570/111359457-c2dd9180-8648-11eb-8044-96ecf8978f55.png)


All workers active at a time 

![image](https://user-images.githubusercontent.com/5713570/111359556-e1dc2380-8648-11eb-8c15-162b25b88e90.png)
