### PR TITLE
CDAP-17583 Change the offset key to match to the replicator connector name.

### DIFF
--- a/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConstantOffsetBackingStore.java
+++ b/mysql-delta-plugins/src/main/java/io/cdap/delta/mysql/MySqlConstantOffsetBackingStore.java
@@ -42,11 +42,9 @@ public class MySqlConstantOffsetBackingStore extends MemoryOffsetBackingStore {
   static final String ROW = "row";
   static final String EVENT = "event";
   static final String GTID_SET = "gtids";
+  static final String REPLICATION_CONNECTOR_NAME = "replication.connector.name";
 
   private static final Gson GSON = new Gson();
-  // The key is hardcoded here
-  private static final ByteBuffer KEY =
-    StandardCharsets.UTF_8.encode("{\"schema\":null,\"payload\":[\"delta\",{\"server\":\"dummy\"}]}");
 
   @Override
   public void configure(WorkerConfig config) {
@@ -57,7 +55,12 @@ public class MySqlConstantOffsetBackingStore extends MemoryOffsetBackingStore {
     String rowStr = originalConfig.get(ROW);
     String eventStr = originalConfig.get(EVENT);
     String gtidSetStr = originalConfig.get(GTID_SET);
+    String replicationConnectorName = originalConfig.get(REPLICATION_CONNECTOR_NAME);
 
+    ByteBuffer key =
+      StandardCharsets.UTF_8.encode("{\"schema\":null,\"payload\":[\""
+                                      + replicationConnectorName
+                                      + "\",{\"server\":\"dummy\"}]}");
     Map<String, Object> offset = new HashMap<>();
     if (!Strings.isNullOrEmpty(fileStr)) {
       offset.put(FILE, fileStr);
@@ -82,6 +85,6 @@ public class MySqlConstantOffsetBackingStore extends MemoryOffsetBackingStore {
       return;
     }
 
-    data.put(KEY, StandardCharsets.UTF_8.encode(GSON.toJson(offset)));
+    data.put(key, StandardCharsets.UTF_8.encode(GSON.toJson(offset)));
   }
 }

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConstantOffsetBackingStore.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerConstantOffsetBackingStore.java
@@ -33,8 +33,9 @@ import java.util.Map;
  */
 public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStore {
   private static final Gson GSON = new Gson();
-  private static final String KEY = "{\"schema\":null,\"payload\":[\"delta\",{\"server\":\"dummy\"}]}";
+
   static final String SNAPSHOT_COMPLETED = "snapshot_completed";
+  static final String REPLICATION_CONNECTOR_NAME = "replication.connector.name";
 
   @Override
   public void configure(WorkerConfig config) {
@@ -45,7 +46,8 @@ public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStor
     String commitStr = originalConfig.get(SourceInfo.COMMIT_LSN_KEY);
     String snapshot = originalConfig.get(SourceInfo.SNAPSHOT_KEY);
     String snapshotCompleted = originalConfig.get(SNAPSHOT_COMPLETED);
-
+    String replicationConnectorName = originalConfig.get(REPLICATION_CONNECTOR_NAME);
+    String key = "{\"schema\":null,\"payload\":[\"" + replicationConnectorName + "\",{\"server\":\"dummy\"}]}";
     Map<String, Object> offset = new HashMap<>();
     if (!changeStr.isEmpty()) {
       offset.put(SourceInfo.CHANGE_LSN_KEY, changeStr);
@@ -67,6 +69,6 @@ public class SqlServerConstantOffsetBackingStore extends MemoryOffsetBackingStor
     }
     byte[] offsetBytes = Bytes.toBytes(GSON.toJson(offset));
 
-    data.put(ByteBuffer.wrap(Bytes.toBytes(KEY)), ByteBuffer.wrap(offsetBytes));
+    data.put(ByteBuffer.wrap(Bytes.toBytes(key)), ByteBuffer.wrap(offsetBytes));
   }
 }


### PR DESCRIPTION
JIRA: https://cdap.atlassian.net/browse/CDAP-17583

Previously in in-memory offset backing store for sql server and mysql (MySqlConstantOffsetBackingStore.java) we used hard-coded key for storing in-memory offset. However key should contain the app name as well as thats how its formed by debezium while querying the in-memory offset.