### PR TITLE
Throw Runtime Exception for tables without primary key (CDAP-19607)

### DIFF
--- a/sqlserver-delta-plugins/pom.xml
+++ b/sqlserver-delta-plugins/pom.xml
@@ -31,6 +31,7 @@
     <port.file>${project.build.outputDirectory}/port.properties</port.file>
     <sqlserver.image>mcr.microsoft.com/mssql/server:2017-CU19-ubuntu-16.04</sqlserver.image>
     <sqlserver.password>D3ltaPass</sqlserver.password>
+    <powermock.version>2.0.9</powermock.version>
   </properties>
 
   <dependencies>
@@ -54,6 +55,24 @@
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
       <version>8.2.1.jre8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.delta</groupId>
+      <artifactId>delta-api</artifactId>
+      <version>0.8.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sqlserver-delta-plugins/pom.xml
+++ b/sqlserver-delta-plugins/pom.xml
@@ -58,12 +58,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.cdap.delta</groupId>
-      <artifactId>delta-api</artifactId>
-      <version>0.8.0-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <version>${powermock.version}</version>

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
@@ -22,6 +22,7 @@ import io.cdap.delta.api.DDLEvent;
 import io.cdap.delta.api.DDLOperation;
 import io.cdap.delta.api.DMLEvent;
 import io.cdap.delta.api.DMLOperation;
+import io.cdap.delta.api.DeltaFailureRuntimeException;
 import io.cdap.delta.api.DeltaSourceContext;
 import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.Offset;
@@ -121,6 +122,10 @@ public class SqlServerRecordConsumer implements Consumer<SourceRecord> {
     if (!readAllTables && sourceTable == null) {
       // shouldn't happen
       return;
+    }
+    if (sourceRecord.key() == null){
+      throw new DeltaFailureRuntimeException(String.format("Table '%s' in database '%s' has no primary key. Tables without a primary key are" +
+                                                             " not supported.", tableName, databaseName));
     }
 
     StructuredRecord before = val.get("before");

--- a/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
+++ b/sqlserver-delta-plugins/src/main/java/io/cdap/delta/sqlserver/SqlServerRecordConsumer.java
@@ -123,8 +123,9 @@ public class SqlServerRecordConsumer implements Consumer<SourceRecord> {
       // shouldn't happen
       return;
     }
-    if (sourceRecord.key() == null){
-      throw new DeltaFailureRuntimeException(String.format("Table '%s' in database '%s' has no primary key. Tables without a primary key are" +
+    if (sourceRecord.key() == null) {
+      throw new DeltaFailureRuntimeException(String.format("Table '%s' in database '%s' has no primary key. " +
+                                                             "Tables without a primary key are" +
                                                              " not supported.", tableName, databaseName));
     }
 

--- a/sqlserver-delta-plugins/src/test/java/io.cdap.delta.sqlserver/SqlServerRecordConsumerTest.java
+++ b/sqlserver-delta-plugins/src/test/java/io.cdap.delta.sqlserver/SqlServerRecordConsumerTest.java
@@ -1,0 +1,47 @@
+package io.cdap.delta.sqlserver;
+
+import com.microsoft.sqlserver.jdbc.SQLServerDriver;
+import io.cdap.delta.api.DeltaFailureRuntimeException;
+import io.cdap.delta.api.DeltaSourceContext;
+import io.cdap.delta.api.Offset;
+import io.cdap.delta.plugin.mock.MockContext;
+import io.cdap.delta.plugin.mock.MockEventEmitter;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SqlServerRecordConsumerTest {
+  @Test(expected = DeltaFailureRuntimeException.class)
+  public void testTableWithoutPrimaryKey() {
+    DeltaSourceContext context = new MockContext(SQLServerDriver.class);
+    MockEventEmitter eventEmitter = new MockEventEmitter(5);
+    SqlServerRecordConsumer sqlServerRecordConsumer = new SqlServerRecordConsumer(context, eventEmitter, "AdventureWorks2014", new HashSet<>(),
+                                                                                  new HashMap<>(), new Offset(), true);
+    SourceRecord sourceRecordMock = Mockito.mock(SourceRecord.class);
+    // the topic name will always be like this: [db.server.name].[schema].[table]
+    Mockito.when(sourceRecordMock.topic()).thenReturn("dbo.testreplication.npe");
+    List<Field> fields = Arrays.asList(new Field("op", 0, new ConnectSchema(Schema.Type.STRING)));
+    Struct valueStruct = new Struct(new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null, fields, null, null));
+    valueStruct.put("op", "c");
+    Mockito.when(sourceRecordMock.value()).thenReturn(valueStruct);
+    Mockito.when(sourceRecordMock.sourceOffset()).thenReturn(new HashMap() {{
+      put("snapshot", true);
+    }});
+    //set primary key as NULL
+    Mockito.when(sourceRecordMock.key()).thenReturn(null);
+    sqlServerRecordConsumer.accept(sourceRecordMock);
+
+  }
+
+}


### PR DESCRIPTION
Fail the pipeline throwing DeltaFailureRuntimeException, when it is run without primary key in a table.
The error is logged mentioning the table without primary key.
Unit testing done.
Link to the JIRA bug: https://cdap.atlassian.net/browse/CDAP-19607.
