### PR TITLE
Fix CVEs in database-delta-plugins via dependencyManagement overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,30 @@
     </repository>
   </repositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-core</artifactId>
+        <version>1.9.8.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>1.3.15</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.3.15</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>io.debezium</groupId>


### PR DESCRIPTION
Traced transitive vulnerability roots using mvn dependency:tree and applied targeted dependencyManagement overrides for debezium-core (1.9.8.Final), logback-core (1.3.15), logback-classic (1.3.15), and junit (4.13.2).