### PR TITLE
Upgrade GitHub actions v3 to v4 in build and E2E workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,12 @@ jobs:
          && (github.event.action != 'labeled' || github.event.label.name == 'build')
          )
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       # Pinned 1.0.0 version
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: plugin
           submodules: 'recursive'
@@ -61,13 +61,13 @@ jobs:
               - '${{ matrix.module }}/**/e2e-test/**'
 
       - name: Checkout e2e test repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cdapio/cdap-e2e-tests
           path: e2e
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}
@@ -76,7 +76,7 @@ jobs:
 
       - name: Get Secrets from GCP Secret Manager
         id: secrets
-        uses: 'google-github-actions/get-secretmanager-secrets@v0'
+        uses: 'google-github-actions/get-secretmanager-secrets@v2'
         with:
           secrets: |-
             MYSQL_HOST:cdapio-github-builds/MYSQL_HOST
@@ -115,21 +115,21 @@ jobs:
           MSSQL_PORT: ${{ steps.secrets.outputs.MSSQL_PORT }}
 
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Cucumber report - ${{ matrix.module }}
           path: ./**/target/cucumber-reports
 
       - name: Upload debug files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Debug files - ${{ matrix.module }}
           path: ./**/target/e2e-debug
 
       - name: Upload files to GCS
-        uses: google-github-actions/upload-cloud-storage@v0
+        uses: google-github-actions/upload-cloud-storage@v2
         if: always()
         with:
           path: ./plugin


### PR DESCRIPTION
## Description
Upgraded deprecated `v3` GitHub Actions to `v4` across `.github/workflows/build.yml` and `.github/workflows/e2e.yml`.

### Changes Included:
- `actions/checkout@v3` → `actions/checkout@v4`
- `actions/cache@v3` → `actions/cache@v4`
- `actions/upload-artifact@v3` → `actions/upload-artifact@v4`

This resolves the E2E test workflow failures caused by Node/Action runner deprecations in GitHub Actions, matching the fix in [google-cloud commit 1689d47bb5cffa2be8c66ebd6d949bb6e8b0ccd5](https://github.com/data-integrations/google-cloud/commit/1689d47bb5cffa2be8c66ebd6d949bb6e8b0ccd5).
